### PR TITLE
expose pulsein to digital pins

### DIFF
--- a/src/codal_app/microbithal.cpp
+++ b/src/codal_app/microbithal.cpp
@@ -170,6 +170,10 @@ void microbit_hal_pin_write_ws2812(int pin, const uint8_t *buf, size_t len) {
     neopixel_send_buffer(*pin_obj[pin], buf, len);
 }
 
+int microbit_hal_pin_pulsein(int pin, int timeout){
+    return pin_obj[pin]->getPulseUs(timeout);
+}
+
 int microbit_hal_i2c_init(int scl, int sda, int freq) {
     // TODO set pins
     int ret = uBit.i2c.setFrequency(freq);

--- a/src/codal_app/microbithal.h
+++ b/src/codal_app/microbithal.h
@@ -102,6 +102,7 @@ int microbit_hal_pin_read_analog_u10(int pin);
 void microbit_hal_pin_write_analog_u10(int pin, int value);
 int microbit_hal_pin_is_touched(int pin);
 void microbit_hal_pin_write_ws2812(int pin, const uint8_t *buf, size_t len);
+int microbit_hal_pin_pulsein(int pin, int timeout);
 
 int microbit_hal_i2c_init(int scl, int sda, int freq);
 int microbit_hal_i2c_readfrom(uint8_t addr, uint8_t *buf, size_t len, int stop);

--- a/src/codal_port/microbit_pin.c
+++ b/src/codal_port/microbit_pin.c
@@ -197,6 +197,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_pulsein_obj, microbit_pin_pulsein);
 STATIC const mp_rom_map_elem_t microbit_dig_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write_digital), MP_ROM_PTR(&microbit_pin_write_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_digital), MP_ROM_PTR(&microbit_pin_read_digital_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pulsein), MP_ROM_PTR(&microbit_pin_pulsein_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_analog), MP_ROM_PTR(&microbit_pin_write_analog_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_analog_period), MP_ROM_PTR(&microbit_pin_set_analog_period_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_analog_period_microseconds), MP_ROM_PTR(&microbit_pin_set_analog_period_microseconds_obj) },
@@ -217,6 +218,7 @@ const mp_obj_type_t microbit_dig_pin_type = {
 STATIC const mp_rom_map_elem_t microbit_ann_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write_digital), MP_ROM_PTR(&microbit_pin_write_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_digital), MP_ROM_PTR(&microbit_pin_read_digital_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pulsein), MP_ROM_PTR(&microbit_pin_pulsein_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_analog), MP_ROM_PTR(&microbit_pin_write_analog_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_analog), MP_ROM_PTR(&microbit_pin_read_analog_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_analog_period), MP_ROM_PTR(&microbit_pin_set_analog_period_obj) },
@@ -238,6 +240,7 @@ const mp_obj_type_t microbit_ad_pin_type = {
 STATIC const mp_rom_map_elem_t microbit_touch_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write_digital), MP_ROM_PTR(&microbit_pin_write_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_digital), MP_ROM_PTR(&microbit_pin_read_digital_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pulsein), MP_ROM_PTR(&microbit_pin_pulsein_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_analog), MP_ROM_PTR(&microbit_pin_write_analog_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_analog), MP_ROM_PTR(&microbit_pin_read_analog_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_analog_period), MP_ROM_PTR(&microbit_pin_set_analog_period_obj) },
@@ -248,7 +251,6 @@ STATIC const mp_rom_map_elem_t microbit_touch_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_pull), MP_ROM_PTR(&microbit_pin_set_pull_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_mode), MP_ROM_PTR(&microbit_pin_get_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_touch_mode), MP_ROM_PTR(&microbit_pin_set_touch_mode_obj) },
-    { MP_ROM_QSTR(MP_QSTR_pulsein), MP_ROM_PTR(&microbit_pin_pulsein_obj) },
     PULL_CONSTANTS,
     TOUCH_CONSTANTS,
 };

--- a/src/codal_port/microbit_pin.c
+++ b/src/codal_port/microbit_pin.c
@@ -177,6 +177,14 @@ mp_obj_t microbit_pin_set_touch_mode(mp_obj_t self_in, mp_obj_t mode_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_set_touch_mode_obj, microbit_pin_set_touch_mode);
 
+mp_obj_t microbit_pin_pulsein(mp_obj_t self_in, mp_obj_t timeout_in) {
+    microbit_pin_obj_t *self = (microbit_pin_obj_t *)self_in;
+    int tick = microbit_hal_pin_pulsein(self->name, mp_obj_get_int(timeout_in));
+    return mp_obj_new_int(tick);
+}
+MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_pulsein_obj, microbit_pin_pulsein);
+
+
 #define PULL_CONSTANTS \
     { MP_ROM_QSTR(MP_QSTR_PULL_UP), MP_ROM_INT(MICROBIT_HAL_PIN_PULL_UP) }, \
     { MP_ROM_QSTR(MP_QSTR_PULL_DOWN), MP_ROM_INT(MICROBIT_HAL_PIN_PULL_DOWN) }, \
@@ -240,6 +248,7 @@ STATIC const mp_rom_map_elem_t microbit_touch_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_pull), MP_ROM_PTR(&microbit_pin_set_pull_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_mode), MP_ROM_PTR(&microbit_pin_get_mode_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_touch_mode), MP_ROM_PTR(&microbit_pin_set_touch_mode_obj) },
+    { MP_ROM_QSTR(MP_QSTR_pulsein), MP_ROM_PTR(&microbit_pin_pulsein_obj) },
     PULL_CONSTANTS,
     TOUCH_CONSTANTS,
 };


### PR DESCRIPTION
This should resolve #26, make hcsr04 works with newbit. Tested with the following code snippet:
```
def sonar(p):
  p.write_digital(0)
  sleep_us(2)
  p.write_digital(1)
  sleep_us(10)
  p.write_digital(0)
  p.read_digital()
  duration = p.pulsein(2000)
  if duration<0:
    return -1
  return (duration/2)/29.1
```
