### PR TITLE
Added possibility to use +8 dBm TX power for micro:bit v2 as nRF52833 supported

### DIFF
--- a/src/codal_port/drv_radio.c
+++ b/src/codal_port/drv_radio.c
@@ -93,7 +93,7 @@ void microbit_radio_enable(microbit_radio_config_t *config) {
     while (NRF_CLOCK->EVENTS_HFCLKSTARTED == 0) {
     }
 
-    // power should be one of: -30, -20, -16, -12, -8, -4, 0, 4
+    // power should be one of: -30, -20, -16, -12, -8, -4, 0, 4, 8
     NRF_RADIO->TXPOWER = config->power_dbm;
 
     // should be between 0 and 100 inclusive (actual physical freq is 2400MHz + this register)

--- a/src/codal_port/drv_radio.h
+++ b/src/codal_port/drv_radio.h
@@ -57,7 +57,7 @@ typedef struct _microbit_radio_config_t {
     uint8_t max_payload;    // 1-251 inclusive
     uint8_t queue_len;      // 1-254 inclusive
     uint8_t channel;        // 0-100 inclusive
-    int8_t power_dbm;       // one of: -30, -20, -16, -12, -8, -4, 0, 4
+    int8_t power_dbm;       // one of: -30, -20, -16, -12, -8, -4, 0, 4, 8
     uint32_t base0;         // for BASE0 register
     uint8_t prefix0;        // for PREFIX0 register (lower 8 bits only)
     uint8_t data_rate;      // one of: RADIO_MODE_MODE_Nrf_{250Kbit,1Mbit,2Mbit}

--- a/src/codal_port/modradio.c
+++ b/src/codal_port/modradio.c
@@ -90,10 +90,10 @@ STATIC mp_obj_t mod_radio_config(size_t n_args, const mp_obj_t *pos_args, mp_map
                     break;
 
                 case MP_QSTR_power: {
-                    if (!(0 <= value && value <= 7)) {
+                    if (!(0 <= value && value <= 8)) {
                         goto value_error;
                     }
-                    static int8_t power_dbm_table[8] = {-30, -20, -16, -12, -8, -4, 0, 4};
+                    static int8_t power_dbm_table[9] = {-30, -20, -16, -12, -8, -4, 0, 4, 8};
                     new_config.power_dbm = power_dbm_table[value];
                     break;
                 }


### PR DESCRIPTION
Hello.
According to nRF52833 specs chip is supported TX power up to +8 dBm. But now we can use only +4 dBm maximum from micropython.
This change adds possibility to use +8 dBm TX power for micro:bit v2.

Thank you.