### PR TITLE
codal_port/modspeech: Allow background processing for the sake of the browser/simulator

### DIFF
--- a/src/codal_port/modspeech.c
+++ b/src/codal_port/modspeech.c
@@ -115,6 +115,8 @@ STATIC void speech_wait_output_drained(void) {
     #if USE_DEDICATED_AUDIO_CHANNEL
     while (speech_output_read >= 0) {
         mp_handle_pending(true);
+        extern void microbit_hal_background_processing(void);
+        microbit_hal_background_processing();
     }
     uint32_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     int x = speech_output_read;


### PR DESCRIPTION
@dpgeorge for speech to work in audio this while needs to relinquish control to the browser.

Raising as a draft PR just to clearly indicate the point that needs to yield but no expectation that we'd merge it like this.

Is there a suitable hook to call? microbit_hal_background_processing might be doing too much?