### PR TITLE
microbit_hal: Consistent values for mic levels

### DIFF
--- a/src/codal_app/microbithal_microphone.cpp
+++ b/src/codal_app/microbithal_microphone.cpp
@@ -51,7 +51,7 @@ void microbit_hal_microphone_init(void) {
 
 void microbit_hal_microphone_set_threshold(int kind, int value) {
     value = value * SOUND_LEVEL_MAXIMUM / 255;
-    if (kind == 0) {
+    if (kind == MICROBIT_HAL_MICROPHONE_LEVEL_THRESHOLD_LOW) {
         level->setLowThreshold(value);
     } else {
         level->setHighThreshold(value);

--- a/src/codal_port/microbit_microphone.c
+++ b/src/codal_port/microbit_microphone.c
@@ -85,9 +85,9 @@ STATIC mp_obj_t microbit_microphone_set_threshold(mp_obj_t self_in, mp_obj_t sou
     uint8_t sound = sound_event_from_obj(sound_in);
     int kind;
     if (sound == SOUND_EVENT_QUIET) {
-        kind = 0;
+        kind = MICROBIT_HAL_MICROPHONE_LEVEL_THRESHOLD_LOW;
     } else if (sound == SOUND_EVENT_LOUD) {
-        kind = 1;
+        kind = MICROBIT_HAL_MICROPHONE_LEVEL_THRESHOLD_HIGH;
     } else {
         mp_raise_ValueError(MP_ERROR_TEXT("invalid sound"));
     }


### PR DESCRIPTION
HAL implementers need to work with both
microbit_hal_level_detector_callback and
microbit_hal_microphone_set_threshold. It's confusing for the former to
use 1 and 2 and the latter 0 and 1 to represent low and high.

Consistently use 1 and 2 via the HAL defines.