### PR TITLE
Update CODAL to v0.2.42, use interruptable deepSleep(), and tag 2.0.0-beta.2

### DIFF
--- a/src/codal_app/codal.json
+++ b/src/codal_app/codal.json
@@ -2,7 +2,7 @@
     "target": {
         "name": "codal-microbit-v2",
         "url": "https://github.com/lancaster-university/codal-microbit-v2",
-        "branch": "v0.2.40",
+        "branch": "v0.2.42",
         "type": "git",
         "test_ignore": true
     } ,

--- a/src/codal_app/microbithal.cpp
+++ b/src/codal_app/microbithal.cpp
@@ -129,7 +129,7 @@ void microbit_hal_power_off(void) {
 
 void microbit_hal_power_deep_sleep(bool wake_on_ms, uint32_t ms) {
     if (wake_on_ms) {
-        uBit.power.deepSleep(ms);
+        uBit.power.deepSleep(ms, true);
     } else {
         uBit.power.deepSleep();
     }

--- a/src/codal_port/mpconfigport.h
+++ b/src/codal_port/mpconfigport.h
@@ -116,7 +116,7 @@
     { MP_ROM_QSTR(MP_QSTR_open), MP_ROM_PTR(&mp_builtin_open_obj) },
 #endif
 
-#define MICROBIT_RELEASE "2.1.0-beta.1"
+#define MICROBIT_RELEASE "2.1.0-beta.2"
 #define MICROBIT_BOARD_NAME "micro:bit"
 #define MICROPY_HW_BOARD_NAME MICROBIT_BOARD_NAME " v" MICROBIT_RELEASE
 #define MICROPY_HW_MCU_NAME "nRF52833"


### PR DESCRIPTION
@dpgeorge creating a PR for visibility, I'll merge this today to release a beta.2 with the wave->waveform change for the Python Editor.

Also including the latest CODAL with the interruptable sleep, which I've been testing locally.