### PR TITLE
codal_app: Update codal-microbit-v2 to v0.2.43.

### DIFF
--- a/src/codal_app/codal.json
+++ b/src/codal_app/codal.json
@@ -2,7 +2,7 @@
     "target": {
         "name": "codal-microbit-v2",
         "url": "https://github.com/lancaster-university/codal-microbit-v2",
-        "branch": "v0.2.42-hotfix.1",
+        "branch": "v0.2.43",
         "type": "git",
         "test_ignore": true
     } ,
@@ -11,7 +11,8 @@
         "MICROBIT_BLE_ENABLED" : 0,
         "MICROBIT_BLE_PAIRING_MODE": 1,
         "MICROBIT_BLE_PARTIAL_FLASHING" : 1,
-        "MICROBIT_BLE_SECURITY_MODE": 2
+        "MICROBIT_BLE_SECURITY_MODE": 2,
+        "MICROBIT_USB_SERIAL_WAKE": 1
     },
     "application": "../../src/codal_app",
     "output_folder": "../../src/build"

--- a/src/codal_app/codal.json
+++ b/src/codal_app/codal.json
@@ -12,7 +12,8 @@
         "MICROBIT_BLE_PAIRING_MODE": 1,
         "MICROBIT_BLE_PARTIAL_FLASHING" : 1,
         "MICROBIT_BLE_SECURITY_MODE": 2,
-        "MICROBIT_USB_SERIAL_WAKE": 1
+        "MICROBIT_USB_SERIAL_WAKE": 1,
+        "LEVEL_DETECTOR_SPL_8BIT_000_POINT": 52.0 
     },
     "application": "../../src/codal_app",
     "output_folder": "../../src/build"


### PR DESCRIPTION
Also adds the MICROBIT_USB_SERIAL_WAKE flag to the CODAL config to enable wake up from UART.

Changes to codal-microbit-v2:
- deepSleep() with no wake targets will now actually deep sleep.
- Serial ports can now be used to wake the board from deep sleep.
- New configuration flag MICROBIT_USB_SERIAL_WAKE can now be set to configure the board to wake on serial input.

Changes to codal-core:
- Fixed spurious mic activation due to overlapping device IDs between CodalComponent and MicroBitCompat.

-----

@dpgeorge This is what I've been using for the latest MicroPython testing. Feel free to close the PR if you prefer to update the CODAL tag differently or with other code changes.