### PR TITLE
codal_port/modspeech: include mphal.h for the simulator

### DIFF
--- a/src/codal_port/modspeech.c
+++ b/src/codal_port/modspeech.c
@@ -28,6 +28,7 @@
 #include <stdio.h>
 #include <string.h>
 
+#include "py/mphal.h"
 #include "py/obj.h"
 #include "py/objtuple.h"
 #include "py/objstr.h"


### PR DESCRIPTION
MICROPY_BEGIN_ATOMIC_SECTION/MICROPY_END_ATOMIC_SECTION are only defined in modspeech because of mpconfigport.h (indirectly). Include mphal.h so that the defaults are defined if the port does not define them (as in the sim case).