### PR TITLE
codal_port/ticks_cpu: Check CoreDebug DEMCR trace enable bit.

### DIFF
--- a/src/codal_port/mphalport.h
+++ b/src/codal_port/mphalport.h
@@ -46,7 +46,7 @@ static inline void enable_irq(uint32_t state) {
 }
 
 static inline mp_uint_t mp_hal_ticks_cpu(void) {
-    if (!(DWT->CTRL & DWT_CTRL_CYCCNTENA_Msk)) {
+    if (!(DWT->CTRL & DWT_CTRL_CYCCNTENA_Msk) || !(CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk)) {
         CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
         DWT->CYCCNT = 0;
         DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;


### PR DESCRIPTION
The DAPLink controlled reset button performs a target reset via SWD, and the CoreDebug trace enable  bit seems to be cleared while the DWT->CTRL cycle count enable bit is not.

Fixes https://github.com/microbit-foundation/micropython-microbit-v2/issues/179#issuecomment-2059077656.