### PR TITLE
codal_port/Makefile: Keep C/C++ flags set up by MicroPython lib.

### DIFF
--- a/src/codal_port/Makefile
+++ b/src/codal_port/Makefile
@@ -45,7 +45,8 @@ INC += -I$(BUILD)
 CWARN = -Wall -Werror
 CWARN += -Wpointer-arith -Wuninitialized
 CFLAGS_ARCH += -DNRF52833_XXAA
-CFLAGS = $(INC) $(CWARN) -std=c99 $(CFLAGS_MOD) $(CFLAGS_ARCH) $(COPT) $(CFLAGS_EXTRA)
+CFLAGS += $(INC) $(CWARN) -std=c99 $(CFLAGS_MOD) $(CFLAGS_ARCH) $(COPT) $(CFLAGS_EXTRA)
+CXXFLAGS += $(filter-out -std=c99,$(CFLAGS))
 
 # Debugging/Optimization
 ifdef DEBUG
@@ -56,7 +57,7 @@ endif
 
 CFLAGS += -g
 LDFLAGS_ARCH = -Wl,-map,$@.map
-LDFLAGS = $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
+LDFLAGS += $(LDFLAGS_MOD) $(LDFLAGS_ARCH) -lm $(LDFLAGS_EXTRA)
 
 SRC_C += \
 	drv_display.c \


### PR DESCRIPTION
This to be able to create C/C++ modules without modifying files in this repository, as shown in https://github.com/microbit-foundation/micropython-cpp-module-example.

Comparing the flags used before and after this patch:
- The flags generated in the built CMake output files are the same, as those as managed by the CODAL build system
- In the MicroPython c files, the only difference was the addition of ` -DFFCONF_H=\"lib/oofatfs/ffconf.h\" ` define
    - From [micropython/extmod/extmod.mk#L177](https://github.com/micropython/micropython/blob/c3301da17626663d7d6e5fc79a1010842528c9b1/extmod/extmod.mk#L177) 
- The `makeqstrdefs.py` invocation added more flags with the CODAL include paths, my assumption being that this probably won't matter that much if it's only for the qstr generation

The `makeqstrdefs.py`  extra flags added:
```
-I. -I../codal_app -I../../lib -I../../lib/codal/libraries/codal-nrf52/inc/cmsis -I../../lib/codal/libraries/codal-nrf52/nrfx -I../../lib/codal/libraries/codal-nrf52/nrfx/drivers/include -I../../lib/codal/libraries/codal-nrf52/nrfx/hal -I../../lib/codal/libraries/codal-nrf52/nrfx/mdk -I../../lib/micropython -I../../lib/micropython/ports/nrf
```

