### PR TITLE
Update micropython to v1.23

### DIFF
--- a/src/codal_port/drv_display.c
+++ b/src/codal_port/drv_display.c
@@ -44,7 +44,7 @@ static mp_uint_t async_delay = 1000;
 static mp_uint_t async_tick = 0;
 static bool async_clear = false;
 
-STATIC void async_stop(void) {
+static void async_stop(void) {
     async_iterator = NULL;
     async_mode = ASYNC_MODE_STOPPED;
     async_tick = 0;
@@ -62,7 +62,7 @@ void microbit_display_stop(void) {
     MP_STATE_PORT(display_data) = NULL;
 }
 
-STATIC void wait_for_event() {
+static void wait_for_event() {
     while (!wakeup_event) {
         // allow CTRL-C to stop the animation
         if (MP_STATE_THREAD(mp_pending_exception) != MP_OBJ_NULL) {

--- a/src/codal_port/drv_image.c
+++ b/src/codal_port/drv_image.c
@@ -35,7 +35,7 @@ const monochrome_5by5_t microbit_blank_image = {
     { 0, 0, 0 }
 };
 
-STATIC uint8_t monochrome_get_pixel(monochrome_5by5_t *self, mp_int_t x, mp_int_t y) {
+static uint8_t monochrome_get_pixel(monochrome_5by5_t *self, mp_int_t x, mp_int_t y) {
     unsigned int index = y*5+x;
     if (index == 24)
         return self->pixel44;

--- a/src/codal_port/drv_softtimer.c
+++ b/src/codal_port/drv_softtimer.c
@@ -32,7 +32,7 @@
 
 static bool microbit_soft_timer_paused = false;
 
-STATIC int microbit_soft_timer_lt(mp_pairheap_t *n1, mp_pairheap_t *n2) {
+static int microbit_soft_timer_lt(mp_pairheap_t *n1, mp_pairheap_t *n2) {
     microbit_soft_timer_entry_t *e1 = (microbit_soft_timer_entry_t *)n1;
     microbit_soft_timer_entry_t *e2 = (microbit_soft_timer_entry_t *)n2;
     return TICKS_DIFF(e1->expiry_ms, e2->expiry_ms) < 0;

--- a/src/codal_port/iters.c
+++ b/src/codal_port/iters.c
@@ -42,7 +42,7 @@ static mp_obj_t microbit_repeat_iter_next(mp_obj_t iter_in) {
     return mp_obj_subscr(iter->iterable, MP_OBJ_NEW_SMALL_INT(iter->index), MP_OBJ_SENTINEL);
 }
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_repeat_iterator_type,
     MP_QSTR_iterator,
     MP_TYPE_FLAG_ITER_IS_ITERNEXT,

--- a/src/codal_port/main.c
+++ b/src/codal_port/main.c
@@ -96,7 +96,7 @@ void mp_main(void) {
     }
 }
 
-STATIC void microbit_display_exception(mp_obj_t exc_in) {
+static void microbit_display_exception(mp_obj_t exc_in) {
     // Construct the message string ready for display.
     mp_uint_t n, *values;
     mp_obj_exception_get_traceback(exc_in, &n, &values);

--- a/src/codal_port/microbit_accelerometer.c
+++ b/src/codal_port/microbit_accelerometer.c
@@ -36,11 +36,11 @@ typedef struct _microbit_accelerometer_obj_t {
 } microbit_accelerometer_obj_t;
 
 volatile bool accelerometer_up_to_date = false;
-STATIC volatile uint16_t gesture_state = 0;                    // 1 bit per gesture
-STATIC volatile uint8_t gesture_list_cur = 0;                  // index into gesture_list
-STATIC volatile uint8_t gesture_list[GESTURE_LIST_SIZE] = {0}; // list of pending gestures, 4-bits per element
+static volatile uint16_t gesture_state = 0;                    // 1 bit per gesture
+static volatile uint8_t gesture_list_cur = 0;                  // index into gesture_list
+static volatile uint8_t gesture_list[GESTURE_LIST_SIZE] = {0}; // list of pending gestures, 4-bits per element
 
-STATIC const qstr gesture_name_map[] = {
+static const qstr gesture_name_map[] = {
     [MICROBIT_HAL_ACCELEROMETER_EVT_NONE] = MP_QSTR_,
     [MICROBIT_HAL_ACCELEROMETER_EVT_TILT_UP] = MP_QSTR_up,
     [MICROBIT_HAL_ACCELEROMETER_EVT_TILT_DOWN] = MP_QSTR_down,
@@ -56,7 +56,7 @@ STATIC const qstr gesture_name_map[] = {
     [MICROBIT_HAL_ACCELEROMETER_EVT_SHAKE] = MP_QSTR_shake,
 };
 
-STATIC uint32_t gesture_from_obj(mp_obj_t gesture_in) {
+static uint32_t gesture_from_obj(mp_obj_t gesture_in) {
     qstr gesture = mp_obj_str_get_qstr(gesture_in);
     for (uint i = 0; i < MP_ARRAY_SIZE(gesture_name_map); ++i) {
         if (gesture == gesture_name_map[i]) {
@@ -66,7 +66,7 @@ STATIC uint32_t gesture_from_obj(mp_obj_t gesture_in) {
     mp_raise_ValueError(MP_ERROR_TEXT("invalid gesture"));
 }
 
-STATIC void update_for_gesture(void) {
+static void update_for_gesture(void) {
     if (!accelerometer_up_to_date) {
         accelerometer_up_to_date = true;
         int axis[3];
@@ -90,31 +90,31 @@ void microbit_hal_gesture_callback(int value) {
     }
 }
 
-STATIC mp_obj_t microbit_accelerometer_get_x(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_get_x(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_accelerometer_get_sample(axis);
     return mp_obj_new_int(axis[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_x_obj, microbit_accelerometer_get_x);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_x_obj, microbit_accelerometer_get_x);
 
-STATIC mp_obj_t microbit_accelerometer_get_y(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_get_y(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_accelerometer_get_sample(axis);
     return mp_obj_new_int(axis[1]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_y_obj, microbit_accelerometer_get_y);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_y_obj, microbit_accelerometer_get_y);
 
-STATIC mp_obj_t microbit_accelerometer_get_z(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_get_z(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_accelerometer_get_sample(axis);
     return mp_obj_new_int(axis[2]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_z_obj, microbit_accelerometer_get_z);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_z_obj, microbit_accelerometer_get_z);
 
-STATIC mp_obj_t microbit_accelerometer_get_values(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_get_values(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_accelerometer_get_sample(axis);
@@ -125,33 +125,33 @@ STATIC mp_obj_t microbit_accelerometer_get_values(mp_obj_t self_in) {
     };
     return mp_obj_new_tuple(3, tuple);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_values_obj, microbit_accelerometer_get_values);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_values_obj, microbit_accelerometer_get_values);
 
-STATIC mp_obj_t microbit_accelerometer_get_strength(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_get_strength(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_accelerometer_get_sample(axis);
     int strength = sqrtf(axis[0] * axis[0] + axis[1] * axis[1] + axis[2] * axis[2]);
     return mp_obj_new_int(strength);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_strength_obj, microbit_accelerometer_get_strength);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_strength_obj, microbit_accelerometer_get_strength);
 
-STATIC mp_obj_t microbit_accelerometer_current_gesture(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_current_gesture(mp_obj_t self_in) {
     (void)self_in;
     update_for_gesture();
     return MP_OBJ_NEW_QSTR(gesture_name_map[microbit_hal_accelerometer_get_gesture()]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_current_gesture_obj, microbit_accelerometer_current_gesture);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_current_gesture_obj, microbit_accelerometer_current_gesture);
 
-STATIC mp_obj_t microbit_accelerometer_is_gesture(mp_obj_t self_in, mp_obj_t gesture_in) {
+static mp_obj_t microbit_accelerometer_is_gesture(mp_obj_t self_in, mp_obj_t gesture_in) {
     (void)self_in;
     uint32_t gesture = gesture_from_obj(gesture_in);
     update_for_gesture();
     return mp_obj_new_bool(microbit_hal_accelerometer_get_gesture() == gesture);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(microbit_accelerometer_is_gesture_obj, microbit_accelerometer_is_gesture);
+static MP_DEFINE_CONST_FUN_OBJ_2(microbit_accelerometer_is_gesture_obj, microbit_accelerometer_is_gesture);
 
-STATIC mp_obj_t microbit_accelerometer_was_gesture(mp_obj_t self_in, mp_obj_t gesture_in) {
+static mp_obj_t microbit_accelerometer_was_gesture(mp_obj_t self_in, mp_obj_t gesture_in) {
     (void)self_in;
     uint32_t gesture = gesture_from_obj(gesture_in);
     update_for_gesture();
@@ -160,9 +160,9 @@ STATIC mp_obj_t microbit_accelerometer_was_gesture(mp_obj_t self_in, mp_obj_t ge
     gesture_list_cur = 0;
     return result;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(microbit_accelerometer_was_gesture_obj, microbit_accelerometer_was_gesture);
+static MP_DEFINE_CONST_FUN_OBJ_2(microbit_accelerometer_was_gesture_obj, microbit_accelerometer_was_gesture);
 
-STATIC mp_obj_t microbit_accelerometer_get_gestures(mp_obj_t self_in) {
+static mp_obj_t microbit_accelerometer_get_gestures(mp_obj_t self_in) {
     (void)self_in;
     update_for_gesture();
     if (gesture_list_cur == 0) {
@@ -176,16 +176,16 @@ STATIC mp_obj_t microbit_accelerometer_get_gestures(mp_obj_t self_in) {
     gesture_list_cur = 0;
     return o;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_gestures_obj, microbit_accelerometer_get_gestures);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_accelerometer_get_gestures_obj, microbit_accelerometer_get_gestures);
 
-STATIC mp_obj_t microbit_accelerometer_set_range(mp_obj_t self_in, mp_obj_t g) {
+static mp_obj_t microbit_accelerometer_set_range(mp_obj_t self_in, mp_obj_t g) {
     (void)self_in;
     microbit_hal_accelerometer_set_range(mp_obj_get_int(g));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(microbit_accelerometer_set_range_obj, microbit_accelerometer_set_range);
+static MP_DEFINE_CONST_FUN_OBJ_2(microbit_accelerometer_set_range_obj, microbit_accelerometer_set_range);
 
-STATIC const mp_rom_map_elem_t microbit_accelerometer_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_accelerometer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_x), MP_ROM_PTR(&microbit_accelerometer_get_x_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_y), MP_ROM_PTR(&microbit_accelerometer_get_y_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_z), MP_ROM_PTR(&microbit_accelerometer_get_z_obj) },
@@ -197,9 +197,9 @@ STATIC const mp_rom_map_elem_t microbit_accelerometer_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_gestures), MP_ROM_PTR(&microbit_accelerometer_get_gestures_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_range), MP_ROM_PTR(&microbit_accelerometer_set_range_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_accelerometer_locals_dict, microbit_accelerometer_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_accelerometer_locals_dict, microbit_accelerometer_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_accelerometer_type,
     MP_QSTR_MicroBitAccelerometer,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbit_button.c
+++ b/src/codal_port/microbit_button.c
@@ -56,13 +56,13 @@ mp_obj_t microbit_button_was_pressed(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_button_was_pressed_obj, microbit_button_was_pressed);
 
-STATIC const mp_map_elem_t microbit_button_locals_dict_table[] = {
+static const mp_map_elem_t microbit_button_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_is_pressed), (mp_obj_t)&microbit_button_is_pressed_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_was_pressed), (mp_obj_t)&microbit_button_was_pressed_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_get_presses), (mp_obj_t)&microbit_button_get_presses_obj },
 };
 
-STATIC MP_DEFINE_CONST_DICT(microbit_button_locals_dict, microbit_button_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_button_locals_dict, microbit_button_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_button_type,

--- a/src/codal_port/microbit_compass.c
+++ b/src/codal_port/microbit_compass.c
@@ -32,63 +32,63 @@ typedef struct _microbit_compass_obj_t {
     mp_obj_base_t base;
 } microbit_compass_obj_t;
 
-STATIC mp_obj_t microbit_compass_is_calibrated(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_is_calibrated(mp_obj_t self_in) {
     (void)self_in;
     return mp_obj_new_bool(microbit_hal_compass_is_calibrated());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_is_calibrated_obj, microbit_compass_is_calibrated);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_is_calibrated_obj, microbit_compass_is_calibrated);
 
-STATIC mp_obj_t microbit_compass_calibrate(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_calibrate(mp_obj_t self_in) {
     (void)self_in;
     microbit_hal_compass_calibrate();
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_calibrate_obj, microbit_compass_calibrate);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_calibrate_obj, microbit_compass_calibrate);
 
-STATIC mp_obj_t microbit_compass_clear_calibration(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_clear_calibration(mp_obj_t self_in) {
     (void)self_in;
     microbit_hal_compass_clear_calibration();
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_clear_calibration_obj, microbit_compass_clear_calibration);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_clear_calibration_obj, microbit_compass_clear_calibration);
 
-STATIC mp_obj_t microbit_compass_heading(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_heading(mp_obj_t self_in) {
     (void)self_in;
     return mp_obj_new_int(microbit_hal_compass_get_heading());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_heading_obj, microbit_compass_heading);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_heading_obj, microbit_compass_heading);
 
-STATIC mp_obj_t microbit_compass_get_x(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_get_x(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_compass_get_sample(axis);
     return mp_obj_new_int(axis[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_x_obj, microbit_compass_get_x);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_x_obj, microbit_compass_get_x);
 
-STATIC mp_obj_t microbit_compass_get_y(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_get_y(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_compass_get_sample(axis);
     return mp_obj_new_int(axis[1]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_y_obj, microbit_compass_get_y);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_y_obj, microbit_compass_get_y);
 
-STATIC mp_obj_t microbit_compass_get_z(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_get_z(mp_obj_t self_in) {
     (void)self_in;
     int axis[3];
     microbit_hal_compass_get_sample(axis);
     return mp_obj_new_int(axis[2]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_z_obj, microbit_compass_get_z);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_z_obj, microbit_compass_get_z);
 
-STATIC mp_obj_t microbit_compass_get_field_strength(mp_obj_t self_in) {
+static mp_obj_t microbit_compass_get_field_strength(mp_obj_t self_in) {
     (void)self_in;
     return mp_obj_new_int(microbit_hal_compass_get_field_strength());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_field_strength_obj, microbit_compass_get_field_strength);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_compass_get_field_strength_obj, microbit_compass_get_field_strength);
 
-STATIC const mp_rom_map_elem_t microbit_compass_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_compass_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_heading), MP_ROM_PTR(&microbit_compass_heading_obj) },
     { MP_ROM_QSTR(MP_QSTR_is_calibrated), MP_ROM_PTR(&microbit_compass_is_calibrated_obj) },
     { MP_ROM_QSTR(MP_QSTR_calibrate), MP_ROM_PTR(&microbit_compass_calibrate_obj) },
@@ -98,9 +98,9 @@ STATIC const mp_rom_map_elem_t microbit_compass_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_z), MP_ROM_PTR(&microbit_compass_get_z_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_field_strength), MP_ROM_PTR(&microbit_compass_get_field_strength_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_compass_locals_dict, microbit_compass_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_compass_locals_dict, microbit_compass_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_compass_type,
     MP_QSTR_MicroBitCompass,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbit_display.c
+++ b/src/codal_port/microbit_display.c
@@ -178,7 +178,7 @@ void microbit_display_set_pixel(microbit_display_obj_t *display, mp_int_t x, mp_
     microbit_hal_display_set_pixel(x, y, bright);
 }
 
-STATIC mp_obj_t microbit_display_set_pixel_func(mp_uint_t n_args, const mp_obj_t *args) {
+static mp_obj_t microbit_display_set_pixel_func(mp_uint_t n_args, const mp_obj_t *args) {
     (void)n_args;
     microbit_display_obj_t *self = (microbit_display_obj_t*)args[0];
     microbit_display_set_pixel(self, mp_obj_get_int(args[1]), mp_obj_get_int(args[2]), mp_obj_get_int(args[3]));
@@ -193,13 +193,13 @@ mp_int_t microbit_display_get_pixel(microbit_display_obj_t *display, mp_int_t x,
     return microbit_hal_display_get_pixel(x, y);
 }
 
-STATIC mp_obj_t microbit_display_get_pixel_func(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
+static mp_obj_t microbit_display_get_pixel_func(mp_obj_t self_in, mp_obj_t x_in, mp_obj_t y_in) {
     microbit_display_obj_t *self = (microbit_display_obj_t*)self_in;
     return MP_OBJ_NEW_SMALL_INT(microbit_display_get_pixel(self, mp_obj_get_int(x_in), mp_obj_get_int(y_in)));
 }
 MP_DEFINE_CONST_FUN_OBJ_3(microbit_display_get_pixel_obj, microbit_display_get_pixel_func);
 
-STATIC const mp_rom_map_elem_t microbit_display_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_display_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_pixel), MP_ROM_PTR(&microbit_display_get_pixel_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_pixel), MP_ROM_PTR(&microbit_display_set_pixel_obj) },
     { MP_ROM_QSTR(MP_QSTR_show), MP_ROM_PTR(&microbit_display_show_obj) },
@@ -210,9 +210,9 @@ STATIC const mp_rom_map_elem_t microbit_display_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_is_on), MP_ROM_PTR(&microbit_display_is_on_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_light_level),MP_ROM_PTR(&microbit_display_read_light_level_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_display_locals_dict, microbit_display_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_display_locals_dict, microbit_display_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_display_type,
     MP_QSTR_MicroBitDisplay,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbit_i2c.c
+++ b/src/codal_port/microbit_i2c.c
@@ -35,7 +35,7 @@ typedef struct _microbit_i2c_obj_t {
     const microbit_pin_obj_t *sda;
 } microbit_i2c_obj_t;
 
-STATIC mp_obj_t microbit_i2c_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_i2c_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_freq, ARG_sda, ARG_scl };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_freq, MP_ARG_INT, {.u_int = 100000} },
@@ -72,7 +72,7 @@ STATIC mp_obj_t microbit_i2c_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_i2c_init_obj, 1, microbit_i2c_init);
 
-STATIC mp_obj_t microbit_i2c_scan(mp_obj_t self_in) {
+static mp_obj_t microbit_i2c_scan(mp_obj_t self_in) {
     mp_obj_t list = mp_obj_new_list(0, NULL);
     // 7-bit addresses 0b0000xxx and 0b1111xxx are reserved
     for (int addr = 0x08; addr < 0x78; ++addr) {
@@ -85,7 +85,7 @@ STATIC mp_obj_t microbit_i2c_scan(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_i2c_scan_obj, microbit_i2c_scan);
 
-STATIC mp_obj_t microbit_i2c_read(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_i2c_read(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_addr, ARG_n, ARG_repeat };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_addr,     MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
@@ -113,7 +113,7 @@ STATIC mp_obj_t microbit_i2c_read(mp_uint_t n_args, const mp_obj_t *pos_args, mp
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_i2c_read_obj, 1, microbit_i2c_read);
 
-STATIC mp_obj_t microbit_i2c_write(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_i2c_write(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_addr, ARG_buf, ARG_repeat };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_addr,     MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
@@ -140,15 +140,15 @@ STATIC mp_obj_t microbit_i2c_write(mp_uint_t n_args, const mp_obj_t *pos_args, m
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_i2c_write_obj, 1, microbit_i2c_write);
 
-STATIC const mp_rom_map_elem_t microbit_i2c_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_i2c_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&microbit_i2c_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_scan), MP_ROM_PTR(&microbit_i2c_scan_obj) },
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&microbit_i2c_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&microbit_i2c_write_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_i2c_locals_dict, microbit_i2c_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_i2c_locals_dict, microbit_i2c_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_i2c_type,
     MP_QSTR_MicroBitI2C,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbit_image.c
+++ b/src/codal_port/microbit_image.c
@@ -29,7 +29,7 @@
 #include "py/mphal.h"
 #include "modmicrobit.h"
 
-STATIC void microbit_image_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+static void microbit_image_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     microbit_image_obj_t *self = (microbit_image_obj_t*)self_in;
     mp_printf(print, "Image(");
     if (kind == PRINT_STR) {
@@ -51,7 +51,7 @@ STATIC void microbit_image_print(const mp_print_t *print, mp_obj_t self_in, mp_p
     mp_printf(print, ")");
 }
 
-STATIC microbit_image_obj_t *image_from_parsed_str(const char *s, mp_int_t len) {
+static microbit_image_obj_t *image_from_parsed_str(const char *s, mp_int_t len) {
     mp_int_t w = 0;
     mp_int_t h = 0;
     mp_int_t line_len = 0;
@@ -108,7 +108,7 @@ STATIC microbit_image_obj_t *image_from_parsed_str(const char *s, mp_int_t len) 
 }
 
 
-STATIC mp_obj_t microbit_image_make_new(const mp_obj_type_t *type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+static mp_obj_t microbit_image_make_new(const mp_obj_type_t *type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
     (void)type_in;
     mp_arg_check_num(n_args, n_kw, 0, 3, false);
 
@@ -177,7 +177,7 @@ greyscale_t *image_shift(microbit_image_obj_t *self, mp_int_t x, mp_int_t y) {
     return result;
 }
 
-STATIC microbit_image_obj_t *image_crop(microbit_image_obj_t *img, mp_int_t x, mp_int_t y, mp_int_t w, mp_int_t h) {
+static microbit_image_obj_t *image_crop(microbit_image_obj_t *img, mp_int_t x, mp_int_t y, mp_int_t w, mp_int_t h) {
     if (w < 0) {
         w = 0;
     }
@@ -338,7 +338,7 @@ mp_obj_t microbit_image_invert(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_image_invert_obj, microbit_image_invert);
 
-STATIC const mp_rom_map_elem_t microbit_image_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_image_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_width), MP_ROM_PTR(&microbit_image_width_obj) },
     { MP_ROM_QSTR(MP_QSTR_height), MP_ROM_PTR(&microbit_image_height_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_pixel), MP_ROM_PTR(&microbit_image_get_pixel_obj) },
@@ -420,9 +420,9 @@ STATIC const mp_rom_map_elem_t microbit_image_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_SNAKE), MP_ROM_PTR(&microbit_const_image_snake_obj) },
     { MP_ROM_QSTR(MP_QSTR_SCISSORS), MP_ROM_PTR(&microbit_const_image_scissors_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_image_locals_dict, microbit_image_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_image_locals_dict, microbit_image_locals_dict_table);
 
-STATIC const unsigned char *get_font_data_from_char(char c) {
+static const unsigned char *get_font_data_from_char(char c) {
     const uint8_t *data = microbit_hal_get_font_data(c);
     if (data == NULL) {
         data = microbit_hal_get_font_data('?');
@@ -430,12 +430,12 @@ STATIC const unsigned char *get_font_data_from_char(char c) {
     return data;
 }
 
-STATIC mp_int_t get_pixel_from_font_data(const unsigned char *data, int x, int y) {
+static mp_int_t get_pixel_from_font_data(const unsigned char *data, int x, int y) {
     // The following logic belongs in MicroBitFont
     return ((data[y] >> (4 - x)) & 1);
 }
 
-STATIC void microbit_image_set_from_char(greyscale_t *img, char c) {
+static void microbit_image_set_from_char(greyscale_t *img, char c) {
     const unsigned char *data = get_font_data_from_char(c);
     for (int x = 0; x < MICROBIT_DISPLAY_WIDTH; ++x) {
         for (int y = 0; y < MICROBIT_DISPLAY_HEIGHT; ++y) {
@@ -464,7 +464,7 @@ microbit_image_obj_t *microbit_image_dim(microbit_image_obj_t *lhs, mp_float_t f
     return (microbit_image_obj_t *)result;
 }
 
-STATIC microbit_image_obj_t *microbit_image_sum(microbit_image_obj_t *lhs, microbit_image_obj_t *rhs, bool add) {
+static microbit_image_obj_t *microbit_image_sum(microbit_image_obj_t *lhs, microbit_image_obj_t *rhs, bool add) {
     mp_int_t h = image_height(lhs);
     mp_int_t w = image_width(lhs);
     if (image_height(rhs) != h || image_width(rhs) != w) {
@@ -487,7 +487,7 @@ STATIC microbit_image_obj_t *microbit_image_sum(microbit_image_obj_t *lhs, micro
     return (microbit_image_obj_t *)result;
 }
 
-STATIC mp_obj_t image_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t image_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     if (mp_obj_get_type(lhs_in) != &microbit_image_type) {
         return MP_OBJ_NULL; // op not supported
     }
@@ -558,7 +558,7 @@ mp_obj_t scrolling_string_image_iterable(const char* str, mp_uint_t len, mp_obj_
     return result;
 }
 
-STATIC int font_column_non_blank(const unsigned char *font_data, unsigned int col) {
+static int font_column_non_blank(const unsigned char *font_data, unsigned int col) {
     for (int y = 0; y < MICROBIT_DISPLAY_HEIGHT; ++y) {
         if (get_pixel_from_font_data(font_data, col, y)) {
             return 1;
@@ -568,7 +568,7 @@ STATIC int font_column_non_blank(const unsigned char *font_data, unsigned int co
 }
 
 /* Not strictly the rightmost non-blank column, but the rightmost in columns 2,3 or 4. */
-STATIC unsigned int rightmost_non_blank_column(const unsigned char *font_data) {
+static unsigned int rightmost_non_blank_column(const unsigned char *font_data) {
     if (font_column_non_blank(font_data, 4)) {
         return 4;
     }
@@ -594,7 +594,7 @@ static void restart(scrolling_string_iterator_t *iter) {
     }
 }
 
-STATIC mp_obj_t get_microbit_scrolling_string_iter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
+static mp_obj_t get_microbit_scrolling_string_iter(mp_obj_t o_in, mp_obj_iter_buf_t *iter_buf) {
     (void)iter_buf; // not big enough to hold scrolling_string_iterator_t
     scrolling_string_t *str = (scrolling_string_t *)o_in;
     scrolling_string_iterator_t *result = m_new_obj(scrolling_string_iterator_t);
@@ -609,7 +609,7 @@ STATIC mp_obj_t get_microbit_scrolling_string_iter(mp_obj_t o_in, mp_obj_iter_bu
     return result;
 }
 
-STATIC mp_obj_t microbit_scrolling_string_iter_next(mp_obj_t o_in) {
+static mp_obj_t microbit_scrolling_string_iter_next(mp_obj_t o_in) {
     scrolling_string_iterator_t *iter = (scrolling_string_iterator_t *)o_in;
     if (iter->next_char == iter->end && iter->offset == 5) {
         if (iter->repeat) {
@@ -709,7 +709,7 @@ static mp_obj_t facade_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
 
 static mp_obj_t microbit_facade_iterator(mp_obj_t iterable_in, mp_obj_iter_buf_t *iter_buf);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     string_image_facade_type,
     MP_QSTR_Facade,
     MP_TYPE_FLAG_ITER_IS_GETITER,

--- a/src/codal_port/microbit_microphone.c
+++ b/src/codal_port/microbit_microphone.c
@@ -71,11 +71,11 @@ void microbit_hal_level_detector_callback(int value) {
     }
 }
 
-STATIC void microphone_init(void) {
+static void microphone_init(void) {
     microbit_hal_microphone_init();
 }
 
-STATIC uint8_t sound_event_from_obj(mp_obj_t sound) {
+static uint8_t sound_event_from_obj(mp_obj_t sound) {
     for (uint8_t i = 0; i < MP_ARRAY_SIZE(sound_event_obj_map); ++i) {
         if (sound == sound_event_obj_map[i]) {
             return i;
@@ -84,7 +84,7 @@ STATIC uint8_t sound_event_from_obj(mp_obj_t sound) {
     mp_raise_ValueError(MP_ERROR_TEXT("invalid sound"));
 }
 
-STATIC mp_obj_t microbit_microphone_set_threshold(mp_obj_t self_in, mp_obj_t sound_in, mp_obj_t value_in) {
+static mp_obj_t microbit_microphone_set_threshold(mp_obj_t self_in, mp_obj_t sound_in, mp_obj_t value_in) {
     (void)self_in;
     uint8_t sound = sound_event_from_obj(sound_in);
     int kind;
@@ -100,31 +100,31 @@ STATIC mp_obj_t microbit_microphone_set_threshold(mp_obj_t self_in, mp_obj_t sou
     microbit_hal_microphone_set_threshold(kind, value);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_3(microbit_microphone_set_threshold_obj, microbit_microphone_set_threshold);
+static MP_DEFINE_CONST_FUN_OBJ_3(microbit_microphone_set_threshold_obj, microbit_microphone_set_threshold);
 
-STATIC mp_obj_t microbit_microphone_sound_level(mp_obj_t self_in) {
+static mp_obj_t microbit_microphone_sound_level(mp_obj_t self_in) {
     (void)self_in;
     microphone_init();
     return MP_OBJ_NEW_SMALL_INT(microbit_hal_microphone_get_level());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_microphone_sound_level_obj, microbit_microphone_sound_level);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_microphone_sound_level_obj, microbit_microphone_sound_level);
 
-STATIC mp_obj_t microbit_microphone_current_event(mp_obj_t self_in) {
+static mp_obj_t microbit_microphone_current_event(mp_obj_t self_in) {
     (void)self_in;
     microphone_init();
     return (mp_obj_t)sound_event_obj_map[sound_event_current];
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_microphone_current_event_obj, microbit_microphone_current_event);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_microphone_current_event_obj, microbit_microphone_current_event);
 
-STATIC mp_obj_t microbit_microphone_is_event(mp_obj_t self_in, mp_obj_t sound_in) {
+static mp_obj_t microbit_microphone_is_event(mp_obj_t self_in, mp_obj_t sound_in) {
     (void)self_in;
     microphone_init();
     uint8_t sound = sound_event_from_obj(sound_in);
     return mp_obj_new_bool(sound == sound_event_current);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(microbit_microphone_is_event_obj, microbit_microphone_is_event);
+static MP_DEFINE_CONST_FUN_OBJ_2(microbit_microphone_is_event_obj, microbit_microphone_is_event);
 
-STATIC mp_obj_t microbit_microphone_was_event(mp_obj_t self_in, mp_obj_t sound_in) {
+static mp_obj_t microbit_microphone_was_event(mp_obj_t self_in, mp_obj_t sound_in) {
     (void)self_in;
     microphone_init();
     uint8_t sound = sound_event_from_obj(sound_in);
@@ -133,9 +133,9 @@ STATIC mp_obj_t microbit_microphone_was_event(mp_obj_t self_in, mp_obj_t sound_i
     sound_event_history_index = 0;
     return result;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(microbit_microphone_was_event_obj, microbit_microphone_was_event);
+static MP_DEFINE_CONST_FUN_OBJ_2(microbit_microphone_was_event_obj, microbit_microphone_was_event);
 
-STATIC mp_obj_t microbit_microphone_get_events(mp_obj_t self_in) {
+static mp_obj_t microbit_microphone_get_events(mp_obj_t self_in) {
     (void)self_in;
     microphone_init();
     if (sound_event_history_index == 0) {
@@ -149,9 +149,9 @@ STATIC mp_obj_t microbit_microphone_get_events(mp_obj_t self_in) {
     sound_event_history_index = 0;
     return o;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_microphone_get_events_obj, microbit_microphone_get_events);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_microphone_get_events_obj, microbit_microphone_get_events);
 
-STATIC const mp_rom_map_elem_t microbit_microphone_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_microphone_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_set_threshold), MP_ROM_PTR(&microbit_microphone_set_threshold_obj) },
     { MP_ROM_QSTR(MP_QSTR_sound_level), MP_ROM_PTR(&microbit_microphone_sound_level_obj) },
     { MP_ROM_QSTR(MP_QSTR_current_event), MP_ROM_PTR(&microbit_microphone_current_event_obj) },
@@ -159,7 +159,7 @@ STATIC const mp_rom_map_elem_t microbit_microphone_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_was_event), MP_ROM_PTR(&microbit_microphone_was_event_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_events), MP_ROM_PTR(&microbit_microphone_get_events_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_microphone_locals_dict, microbit_microphone_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_microphone_locals_dict, microbit_microphone_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_microphone_type,

--- a/src/codal_port/microbit_pin.c
+++ b/src/codal_port/microbit_pin.c
@@ -204,7 +204,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(microbit_pin_set_touch_mode_obj, microbit_pin_set_touc
     { MP_ROM_QSTR(MP_QSTR_RESISTIVE), MP_ROM_INT(MICROBIT_HAL_PIN_TOUCH_RESISTIVE) }, \
     { MP_ROM_QSTR(MP_QSTR_CAPACITIVE), MP_ROM_INT(MICROBIT_HAL_PIN_TOUCH_CAPACITIVE) }
 
-STATIC const mp_rom_map_elem_t microbit_dig_pin_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_dig_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write_digital), MP_ROM_PTR(&microbit_pin_write_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_digital), MP_ROM_PTR(&microbit_pin_read_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_analog), MP_ROM_PTR(&microbit_pin_write_analog_obj) },
@@ -216,7 +216,7 @@ STATIC const mp_rom_map_elem_t microbit_dig_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_mode), MP_ROM_PTR(&microbit_pin_get_mode_obj) },
     PULL_CONSTANTS,
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_dig_pin_locals_dict, microbit_dig_pin_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_dig_pin_locals_dict, microbit_dig_pin_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_dig_pin_type,
@@ -225,7 +225,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &microbit_dig_pin_locals_dict
     );
 
-STATIC const mp_rom_map_elem_t microbit_ann_pin_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_ann_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write_digital), MP_ROM_PTR(&microbit_pin_write_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_digital), MP_ROM_PTR(&microbit_pin_read_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_analog), MP_ROM_PTR(&microbit_pin_write_analog_obj) },
@@ -238,7 +238,7 @@ STATIC const mp_rom_map_elem_t microbit_ann_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_get_mode), MP_ROM_PTR(&microbit_pin_get_mode_obj) },
     PULL_CONSTANTS,
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_ann_pin_locals_dict, microbit_ann_pin_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_ann_pin_locals_dict, microbit_ann_pin_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_ad_pin_type,
@@ -247,7 +247,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &microbit_ann_pin_locals_dict
     );
 
-STATIC const mp_rom_map_elem_t microbit_touch_pin_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_touch_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_write_digital), MP_ROM_PTR(&microbit_pin_write_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_read_digital), MP_ROM_PTR(&microbit_pin_read_digital_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_analog), MP_ROM_PTR(&microbit_pin_write_analog_obj) },
@@ -265,7 +265,7 @@ STATIC const mp_rom_map_elem_t microbit_touch_pin_locals_dict_table[] = {
     PULL_CONSTANTS,
     TOUCH_CONSTANTS,
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_touch_pin_locals_dict, microbit_touch_pin_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_touch_pin_locals_dict, microbit_touch_pin_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_touch_pin_type,
@@ -274,14 +274,14 @@ MP_DEFINE_CONST_OBJ_TYPE(
     locals_dict, &microbit_touch_pin_locals_dict
     );
 
-STATIC const mp_rom_map_elem_t microbit_touch_only_pin_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_touch_only_pin_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_is_touched), MP_ROM_PTR(&microbit_pin_is_touched_obj) },
     { MP_ROM_QSTR(MP_QSTR_was_touched), MP_ROM_PTR(&microbit_pin_was_touched_obj) },
     { MP_ROM_QSTR(MP_QSTR_get_touches), MP_ROM_PTR(&microbit_pin_get_touches_obj) },
     { MP_ROM_QSTR(MP_QSTR_set_touch_mode), MP_ROM_PTR(&microbit_pin_set_touch_mode_obj) },
     TOUCH_CONSTANTS,
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_touch_only_pin_locals_dict, microbit_touch_only_pin_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_touch_only_pin_locals_dict, microbit_touch_only_pin_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_touch_only_pin_type,

--- a/src/codal_port/microbit_pinaudio.c
+++ b/src/codal_port/microbit_pinaudio.c
@@ -28,7 +28,7 @@
 #include "modmicrobit.h"
 
 // The currently selected pin output for the audio.
-STATIC const microbit_pin_obj_t *audio_routed_pin = NULL;
+static const microbit_pin_obj_t *audio_routed_pin = NULL;
 
 void microbit_pin_audio_select(mp_const_obj_t select, const microbit_pinmode_t *pinmode) {
     // Work out which pins are requested for the audio output.

--- a/src/codal_port/microbit_sound.c
+++ b/src/codal_port/microbit_sound.c
@@ -28,7 +28,7 @@
 #include "modmicrobit.h"
 
 #define SOUND(name, ...) \
-    STATIC const microbit_sound_obj_t microbit_sound_ ## name ## _obj = { \
+    static const microbit_sound_obj_t microbit_sound_ ## name ## _obj = { \
         { &microbit_sound_type }, \
         MP_STRINGIFY(name) \
     }
@@ -46,12 +46,12 @@ SOUND(yawn);
 
 #undef SOUND
 
-STATIC void microbit_sound_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+static void microbit_sound_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     const microbit_sound_obj_t *self = (const microbit_sound_obj_t *)self_in;
     mp_printf(print, "Sound('%s')", self->name);
 }
 
-STATIC const mp_rom_map_elem_t microbit_sound_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_sound_locals_dict_table[] = {
     #define SOUND(NAME, name) { MP_ROM_QSTR(MP_QSTR_ ## NAME), MP_ROM_PTR(&microbit_sound_ ## name ## _obj) }
 
     SOUND(GIGGLE, giggle),
@@ -67,7 +67,7 @@ STATIC const mp_rom_map_elem_t microbit_sound_locals_dict_table[] = {
 
     #undef SOUND
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_sound_locals_dict, microbit_sound_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_sound_locals_dict, microbit_sound_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_sound_type,

--- a/src/codal_port/microbit_soundeffect.c
+++ b/src/codal_port/microbit_soundeffect.c
@@ -98,7 +98,7 @@ typedef struct _soundeffect_attr_t {
     uint8_t length;
 } soundeffect_attr_t;
 
-STATIC const uint16_t waveform_to_qstr_table[5] = {
+static const uint16_t waveform_to_qstr_table[5] = {
     [SOUND_EFFECT_WAVEFORM_SINE] = MP_QSTR_WAVEFORM_SINE,
     [SOUND_EFFECT_WAVEFORM_SAWTOOTH] = MP_QSTR_WAVEFORM_SAWTOOTH,
     [SOUND_EFFECT_WAVEFORM_TRIANGLE] = MP_QSTR_WAVEFORM_TRIANGLE,
@@ -106,14 +106,14 @@ STATIC const uint16_t waveform_to_qstr_table[5] = {
     [SOUND_EFFECT_WAVEFORM_NOISE] = MP_QSTR_WAVEFORM_NOISE,
 };
 
-STATIC const uint16_t fx_to_qstr_table[4] = {
+static const uint16_t fx_to_qstr_table[4] = {
     [SOUND_EFFECT_FX_NONE] = MP_QSTR_FX_NONE,
     [SOUND_EFFECT_FX_TREMOLO] = MP_QSTR_FX_TREMOLO,
     [SOUND_EFFECT_FX_VIBRATO] = MP_QSTR_FX_VIBRATO,
     [SOUND_EFFECT_FX_WARBLE] = MP_QSTR_FX_WARBLE,
 };
 
-STATIC const soundeffect_attr_t soundeffect_attr_table[] = {
+static const soundeffect_attr_t soundeffect_attr_table[] = {
     { MP_QSTR_freq_start, SOUND_EXPR_FREQUENCY_START_OFFSET, SOUND_EXPR_FREQUENCY_START_LENGTH },
     { MP_QSTR_freq_end, SOUND_EXPR_FREQUENCY_END_OFFSET, SOUND_EXPR_FREQUENCY_END_LENGTH },
     { MP_QSTR_duration, SOUND_EXPR_DURATION_OFFSET, SOUND_EXPR_DURATION_LENGTH },
@@ -141,7 +141,7 @@ const char *microbit_soundeffect_get_sound_expr_data(mp_obj_t self_in) {
     return &self->sound_expr[0];
 }
 
-STATIC void sound_expr_encode(microbit_soundeffect_obj_t *self, size_t offset, size_t length, unsigned int value) {
+static void sound_expr_encode(microbit_soundeffect_obj_t *self, size_t offset, size_t length, unsigned int value) {
     if (offset == SOUND_EXPR_VOLUME_START_OFFSET || offset == SOUND_EXPR_VOLUME_END_OFFSET) {
         if (value > 255) {
             mp_raise_ValueError(MP_ERROR_TEXT("maximum value is 255"));
@@ -163,7 +163,7 @@ STATIC void sound_expr_encode(microbit_soundeffect_obj_t *self, size_t offset, s
     }
 }
 
-STATIC unsigned int sound_expr_decode(const microbit_soundeffect_obj_t *self, size_t offset, size_t length) {
+static unsigned int sound_expr_decode(const microbit_soundeffect_obj_t *self, size_t offset, size_t length) {
     unsigned int value = 0;
     for (size_t i = 0; i < length; ++i) {
         value = value * 10 + self->sound_expr[offset + i] - '0';
@@ -174,7 +174,7 @@ STATIC unsigned int sound_expr_decode(const microbit_soundeffect_obj_t *self, si
     return value;
 }
 
-STATIC void microbit_soundeffect_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+static void microbit_soundeffect_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     const microbit_soundeffect_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     unsigned int freq_start = sound_expr_decode(self, SOUND_EXPR_FREQUENCY_START_OFFSET, SOUND_EXPR_FREQUENCY_START_LENGTH);
@@ -228,7 +228,7 @@ STATIC void microbit_soundeffect_print(const mp_print_t *print, mp_obj_t self_in
 
 // Constructor:
 // SoundEffect(freq_start, freq_end, duration, vol_start, vol_end, waveform, fx, shape)
-STATIC mp_obj_t microbit_soundeffect_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args_in) {
+static mp_obj_t microbit_soundeffect_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args_in) {
     enum { ARG_freq_start, ARG_freq_end, ARG_duration, ARG_vol_start, ARG_vol_end, ARG_waveform, ARG_fx, ARG_shape };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_freq_start,       MP_ARG_INT, {.u_int = SOUND_EFFECT_DEFAULT_FREQ_START} },
@@ -270,7 +270,7 @@ STATIC mp_obj_t microbit_soundeffect_make_new(const mp_obj_type_t *type, size_t 
     return MP_OBJ_FROM_PTR(self);
 }
 
-STATIC void microbit_soundeffect_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+static void microbit_soundeffect_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     microbit_soundeffect_obj_t *self = MP_OBJ_TO_PTR(self_in);
     const soundeffect_attr_t *soundeffect_attr = NULL;
     for (size_t i = 0; i < MP_ARRAY_SIZE(soundeffect_attr_table); ++i) {
@@ -303,7 +303,7 @@ STATIC void microbit_soundeffect_attr(mp_obj_t self_in, qstr attr, mp_obj_t *des
     }
 }
 
-STATIC mp_obj_t microbit_soundeffect_from_string(mp_obj_t str_in) {
+static mp_obj_t microbit_soundeffect_from_string(mp_obj_t str_in) {
     microbit_soundeffect_obj_t *self = m_new_obj(microbit_soundeffect_obj_t);
     self->base.type = &microbit_soundeffect_type;
     self->is_mutable = true;
@@ -319,10 +319,10 @@ STATIC mp_obj_t microbit_soundeffect_from_string(mp_obj_t str_in) {
 
     return MP_OBJ_FROM_PTR(self);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_soundeffect_from_string_obj, microbit_soundeffect_from_string);
-STATIC MP_DEFINE_CONST_STATICMETHOD_OBJ(microbit_soundeffect_from_string_staticmethod_obj, MP_ROM_PTR(&microbit_soundeffect_from_string_obj));
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_soundeffect_from_string_obj, microbit_soundeffect_from_string);
+static MP_DEFINE_CONST_STATICMETHOD_OBJ(microbit_soundeffect_from_string_staticmethod_obj, MP_ROM_PTR(&microbit_soundeffect_from_string_obj));
 
-STATIC mp_obj_t microbit_soundeffect_copy(mp_obj_t self_in) {
+static mp_obj_t microbit_soundeffect_copy(mp_obj_t self_in) {
     microbit_soundeffect_obj_t *self = MP_OBJ_TO_PTR(self_in);
     microbit_soundeffect_obj_t *copy = m_new_obj(microbit_soundeffect_obj_t);
     copy->base.type = self->base.type;
@@ -331,9 +331,9 @@ STATIC mp_obj_t microbit_soundeffect_copy(mp_obj_t self_in) {
 
     return MP_OBJ_FROM_PTR(copy);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_soundeffect_copy_obj, microbit_soundeffect_copy);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_soundeffect_copy_obj, microbit_soundeffect_copy);
 
-STATIC const mp_rom_map_elem_t microbit_soundeffect_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_soundeffect_locals_dict_table[] = {
     // Static methods.
     { MP_ROM_QSTR(MP_QSTR__from_string), MP_ROM_PTR(&microbit_soundeffect_from_string_staticmethod_obj) },
 
@@ -360,7 +360,7 @@ STATIC const mp_rom_map_elem_t microbit_soundeffect_locals_dict_table[] = {
 
     #undef C
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_soundeffect_locals_dict, microbit_soundeffect_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_soundeffect_locals_dict, microbit_soundeffect_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_soundeffect_type,

--- a/src/codal_port/microbit_soundevent.c
+++ b/src/codal_port/microbit_soundevent.c
@@ -47,17 +47,17 @@ const microbit_soundevent_obj_t microbit_soundevent_clap_obj = {
     MP_QSTR_clap,
 };
 
-STATIC void microbit_soundevent_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
+static void microbit_soundevent_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     microbit_soundevent_obj_t *self = (microbit_soundevent_obj_t *)self_in;
     mp_printf(print, "SoundEvent('%q')", self->name);
 }
 
-STATIC const mp_rom_map_elem_t microbit_soundevent_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_soundevent_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_LOUD), MP_ROM_PTR(&microbit_soundevent_loud_obj) },
     { MP_ROM_QSTR(MP_QSTR_QUIET), MP_ROM_PTR(&microbit_soundevent_quiet_obj) },
     { MP_ROM_QSTR(MP_QSTR_CLAP), MP_ROM_PTR(&microbit_soundevent_clap_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_soundevent_locals_dict, microbit_soundevent_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_soundevent_locals_dict, microbit_soundevent_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_soundevent_type,

--- a/src/codal_port/microbit_speaker.c
+++ b/src/codal_port/microbit_speaker.c
@@ -32,27 +32,27 @@ typedef struct _microbit_speaker_obj_t {
     mp_obj_base_t base;
 } microbit_speaker_obj_t;
 
-STATIC mp_obj_t microbit_speaker_off(mp_obj_t self_in) {
+static mp_obj_t microbit_speaker_off(mp_obj_t self_in) {
     (void)self_in;
     microbit_hal_audio_select_speaker(false);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_speaker_off_obj, microbit_speaker_off);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_speaker_off_obj, microbit_speaker_off);
 
-STATIC mp_obj_t microbit_speaker_on(mp_obj_t self_in) {
+static mp_obj_t microbit_speaker_on(mp_obj_t self_in) {
     (void)self_in;
     microbit_hal_audio_select_speaker(true);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_speaker_on_obj, microbit_speaker_on);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_speaker_on_obj, microbit_speaker_on);
 
-STATIC const mp_rom_map_elem_t microbit_speaker_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_speaker_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&microbit_speaker_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_on), MP_ROM_PTR(&microbit_speaker_on_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_speaker_locals_dict, microbit_speaker_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_speaker_locals_dict, microbit_speaker_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_speaker_type,
     MP_QSTR_MicroBitSpeaker,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbit_spi.c
+++ b/src/codal_port/microbit_spi.c
@@ -37,15 +37,15 @@ typedef struct _microbit_spi_obj_t {
     const microbit_pin_obj_t *miso;
 } microbit_spi_obj_t;
 
-STATIC bool microbit_spi_initialised = false;
+static bool microbit_spi_initialised = false;
 
-STATIC void microbit_spi_check_initialised(void) {
+static void microbit_spi_check_initialised(void) {
     if (!microbit_spi_initialised) {
         mp_raise_ValueError(MP_ERROR_TEXT("SPI not initialised"));
     }
 }
 
-STATIC mp_obj_t microbit_spi_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_spi_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_baudrate, ARG_bits, ARG_mode, ARG_sclk, ARG_mosi, ARG_miso };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = 1000000} },
@@ -93,7 +93,7 @@ STATIC mp_obj_t microbit_spi_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_spi_init_obj, 1, microbit_spi_init);
 
-STATIC mp_obj_t microbit_spi_write(mp_obj_t self_in, mp_obj_t buf_in) {
+static mp_obj_t microbit_spi_write(mp_obj_t self_in, mp_obj_t buf_in) {
     microbit_spi_check_initialised();
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
@@ -102,7 +102,7 @@ STATIC mp_obj_t microbit_spi_write(mp_obj_t self_in, mp_obj_t buf_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(microbit_spi_write_obj, microbit_spi_write);
 
-STATIC mp_obj_t microbit_spi_read(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t microbit_spi_read(size_t n_args, const mp_obj_t *args) {
     microbit_spi_check_initialised();
     mp_int_t nbytes = mp_obj_get_int(args[1]);
     if (nbytes < 0) {
@@ -123,7 +123,7 @@ STATIC mp_obj_t microbit_spi_read(size_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_spi_read_obj, 2, 3, microbit_spi_read);
 
-STATIC mp_obj_t microbit_spi_write_readinto(mp_obj_t self_in, mp_obj_t write_buf, mp_obj_t read_buf) {
+static mp_obj_t microbit_spi_write_readinto(mp_obj_t self_in, mp_obj_t write_buf, mp_obj_t read_buf) {
     microbit_spi_check_initialised();
     mp_buffer_info_t write_bufinfo;
     mp_get_buffer_raise(write_buf, &write_bufinfo, MP_BUFFER_READ);
@@ -137,15 +137,15 @@ STATIC mp_obj_t microbit_spi_write_readinto(mp_obj_t self_in, mp_obj_t write_buf
 }
 MP_DEFINE_CONST_FUN_OBJ_3(microbit_spi_write_readinto_obj, microbit_spi_write_readinto);
 
-STATIC const mp_rom_map_elem_t microbit_spi_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_spi_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&microbit_spi_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_write), MP_ROM_PTR(&microbit_spi_write_obj) },
     { MP_ROM_QSTR(MP_QSTR_read), MP_ROM_PTR(&microbit_spi_read_obj) },
     { MP_ROM_QSTR(MP_QSTR_write_readinto), MP_ROM_PTR(&microbit_spi_write_readinto_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_spi_locals_dict, microbit_spi_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_spi_locals_dict, microbit_spi_locals_dict_table);
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_spi_type,
     MP_QSTR_MicroBitSPI,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbit_uart.c
+++ b/src/codal_port/microbit_uart.c
@@ -39,9 +39,9 @@ typedef struct _microbit_uart_obj_t {
 } microbit_uart_obj_t;
 
 // timeout (in ms) to wait between characters when reading
-STATIC uint16_t microbit_uart_timeout_char = 0;
+static uint16_t microbit_uart_timeout_char = 0;
 
-STATIC mp_obj_t microbit_uart_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_uart_init(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_baudrate, ARG_bits, ARG_parity, ARG_stop, ARG_pins, ARG_tx, ARG_rx };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_baudrate, MP_ARG_INT, {.u_int = 9600} },
@@ -93,7 +93,7 @@ STATIC mp_obj_t microbit_uart_init(mp_uint_t n_args, const mp_obj_t *pos_args, m
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_uart_init_obj, 1, microbit_uart_init);
 
-STATIC mp_obj_t microbit_uart_any(mp_obj_t self_in) {
+static mp_obj_t microbit_uart_any(mp_obj_t self_in) {
     (void)self_in;
     if (mp_hal_stdio_poll(MP_STREAM_POLL_RD)) {
         return mp_const_true;
@@ -103,7 +103,7 @@ STATIC mp_obj_t microbit_uart_any(mp_obj_t self_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_uart_any_obj, microbit_uart_any);
 
-STATIC const mp_rom_map_elem_t microbit_uart_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_init), MP_ROM_PTR(&microbit_uart_init_obj) },
     { MP_ROM_QSTR(MP_QSTR_any), MP_ROM_PTR(&microbit_uart_any_obj) },
 
@@ -115,11 +115,11 @@ STATIC const mp_rom_map_elem_t microbit_uart_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_ODD), MP_ROM_INT(1) },
     { MP_ROM_QSTR(MP_QSTR_EVEN), MP_ROM_INT(0) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_uart_locals_dict, microbit_uart_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_uart_locals_dict, microbit_uart_locals_dict_table);
 
 // Waits at most timeout_ms for at least 1 char to become ready for reading.
 // Returns true if something available, false if not.
-STATIC bool microbit_uart_rx_wait(uint32_t timeout_ms) {
+static bool microbit_uart_rx_wait(uint32_t timeout_ms) {
     uint32_t start = mp_hal_ticks_ms();
     for (;;) {
         if (mp_hal_stdio_poll(MP_STREAM_POLL_RD)) {
@@ -132,7 +132,7 @@ STATIC bool microbit_uart_rx_wait(uint32_t timeout_ms) {
     }
 }
 
-STATIC mp_uint_t microbit_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
+static mp_uint_t microbit_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t size, int *errcode) {
     (void)self_in;
     byte *buf = (byte*)buf_in;
     (void)errcode;
@@ -159,7 +159,7 @@ STATIC mp_uint_t microbit_uart_read(mp_obj_t self_in, void *buf_in, mp_uint_t si
     }
 }
 
-STATIC mp_uint_t microbit_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
+static mp_uint_t microbit_uart_write(mp_obj_t self_in, const void *buf_in, mp_uint_t size, int *errcode) {
     (void)self_in;
     const char *buf = (const char*)buf_in;
     (void)errcode;
@@ -167,13 +167,13 @@ STATIC mp_uint_t microbit_uart_write(mp_obj_t self_in, const void *buf_in, mp_ui
     return size;
 }
 
-STATIC const mp_stream_p_t microbit_uart_stream_p = {
+static const mp_stream_p_t microbit_uart_stream_p = {
     .read = microbit_uart_read,
     .write = microbit_uart_write,
     .is_text = false,
 };
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_uart_type,
     MP_QSTR_MicroBitUART,
     MP_TYPE_FLAG_NONE,

--- a/src/codal_port/microbitfs.c
+++ b/src/codal_port/microbitfs.c
@@ -125,13 +125,13 @@ extern const mp_obj_type_t os_mbfs_fileio_type;
 extern const mp_obj_type_t os_mbfs_textio_type;
 
 // Page indexes count down from the end of ROM.
-STATIC uint8_t first_page_index;
-STATIC uint8_t last_page_index;
+static uint8_t first_page_index;
+static uint8_t last_page_index;
 // The number of usable chunks in the file system.
-STATIC uint8_t chunks_in_file_system;
+static uint8_t chunks_in_file_system;
 // Index of chunk to start searches. This is randomised to even out wear.
-STATIC uint8_t start_index;
-STATIC file_chunk *file_system_chunks;
+static uint8_t start_index;
+static file_chunk *file_system_chunks;
 
 // Defined by the linker
 extern byte _fs_start[];
@@ -140,25 +140,25 @@ extern byte _fs_end[];
 STATIC_ASSERT((sizeof(file_chunk) == CHUNK_SIZE));
 
 // From micro:bit memory.h
-STATIC inline byte *rounddown(byte *addr, uint32_t align) {
+static inline byte *rounddown(byte *addr, uint32_t align) {
     return (byte*)(((uint32_t)addr)&(-align));
 }
 
 // From micro:bit memory.h
-STATIC inline byte *roundup(byte *addr, uint32_t align) {
+static inline byte *roundup(byte *addr, uint32_t align) {
     return (byte*)((((uint32_t)addr)+align-1)&(-align));
 }
 
 
-STATIC inline void *first_page(void) {
+static inline void *first_page(void) {
     return _fs_end - FLASH_PAGESIZE * first_page_index;
 }
 
-STATIC inline void *last_page(void) {
+static inline void *last_page(void) {
     return _fs_end - FLASH_PAGESIZE * last_page_index;
 }
 
-STATIC void init_limits(void) {
+static void init_limits(void) {
     // First determine where to end
     byte *end = _fs_end;
     end = rounddown(end, FLASH_PAGESIZE)-FLASH_PAGESIZE;
@@ -173,7 +173,7 @@ STATIC void init_limits(void) {
     chunks_in_file_system = (end-start)>>MBFS_LOG_CHUNK_SIZE;
 }
 
-STATIC void randomise_start_index(void) {
+static void randomise_start_index(void) {
     start_index = rng_generate_random_word() % chunks_in_file_system + 1;
 }
 
@@ -191,7 +191,7 @@ void microbit_filesystem_init(void) {
     }
 }
 
-STATIC void copy_page(void *dest, void *src) {
+static void copy_page(void *dest, void *src) {
     DEBUG(("FILE DEBUG: Copying page from %lx to %lx.\r\n", (uint32_t)src, (uint32_t)dest));
     flash_page_erase((uint32_t)dest);
     file_chunk *src_chunk = src;
@@ -214,7 +214,7 @@ STATIC void copy_page(void *dest, void *src) {
 // Then all the pages are copied, one by one, into the adjacent newly unused page.
 // Finally, the persistent data is saved back to the opposite end of the filesystem from whence it came.
 //
-STATIC void filesystem_sweep(void) {
+static void filesystem_sweep(void) {
     persistent_config_t config;
     uint8_t *page;
     uint8_t *end_page;
@@ -244,11 +244,11 @@ STATIC void filesystem_sweep(void) {
 }
 
 
-STATIC inline byte *seek_address(file_descriptor_obj *self) {
+static inline byte *seek_address(file_descriptor_obj *self) {
     return (byte*)&(file_system_chunks[self->seek_chunk].data[self->seek_offset]);
 }
 
-STATIC uint8_t microbit_find_file(const char *name, int name_len) {
+static uint8_t microbit_find_file(const char *name, int name_len) {
     for (uint8_t index = 1; index <= chunks_in_file_system; index++) {
         const file_chunk *p = &file_system_chunks[index];
         if (p->marker != FILE_START)
@@ -272,7 +272,7 @@ STATIC uint8_t microbit_find_file(const char *name, int name_len) {
 // 3a. Sweep the filesystem and restart.
 // 3b. Otherwise, fail and return FILE_NOT_FOUND.
 //
-STATIC uint8_t find_chunk_and_erase(void) {
+static uint8_t find_chunk_and_erase(void) {
     // Start search at a random chunk to spread the wear more evenly.
     // Search for unused chunk
     uint8_t index = start_index;
@@ -320,13 +320,13 @@ STATIC uint8_t find_chunk_and_erase(void) {
     return find_chunk_and_erase();
 }
 
-STATIC mp_obj_t microbit_file_name(file_descriptor_obj *fd) {
+static mp_obj_t microbit_file_name(file_descriptor_obj *fd) {
     return mp_obj_new_str(&(file_system_chunks[fd->start_chunk].header.filename[0]), file_system_chunks[fd->start_chunk].header.name_len);
 }
 
-STATIC file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bool write, bool binary);
+static file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bool write, bool binary);
 
-STATIC void clear_file(uint8_t chunk) {
+static void clear_file(uint8_t chunk) {
     do {
         flash_write_byte((uint32_t)&(file_system_chunks[chunk].marker), FREED_CHUNK);
         DEBUG(("FILE DEBUG: Freeing chunk %d.\n", chunk));
@@ -334,7 +334,7 @@ STATIC void clear_file(uint8_t chunk) {
     } while (chunk <= chunks_in_file_system);
 }
 
-STATIC file_descriptor_obj *microbit_file_open(const char *name, size_t name_len, bool write, bool binary) {
+static file_descriptor_obj *microbit_file_open(const char *name, size_t name_len, bool write, bool binary) {
     if (name_len > MAX_FILENAME_LENGTH) {
         return NULL;
     }
@@ -360,7 +360,7 @@ STATIC file_descriptor_obj *microbit_file_open(const char *name, size_t name_len
     return microbit_file_descriptor_new(index, write, binary);
 }
 
-STATIC file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bool write, bool binary) {
+static file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bool write, bool binary) {
     file_descriptor_obj *res = mp_obj_malloc(file_descriptor_obj, binary ? &os_mbfs_fileio_type : &os_mbfs_textio_type);
     res->start_chunk = start_chunk;
     res->seek_chunk = start_chunk;
@@ -371,7 +371,7 @@ STATIC file_descriptor_obj *microbit_file_descriptor_new(uint8_t start_chunk, bo
     return res;
 }
 
-STATIC mp_obj_t microbit_remove(mp_obj_t filename) {
+static mp_obj_t microbit_remove(mp_obj_t filename) {
     size_t name_len;
     const char *name = mp_obj_str_get_data(filename, &name_len);
     mp_uint_t index = microbit_find_file(name, name_len);
@@ -382,13 +382,13 @@ STATIC mp_obj_t microbit_remove(mp_obj_t filename) {
     return mp_const_none;
 }
 
-STATIC void check_file_open(file_descriptor_obj *self) {
+static void check_file_open(file_descriptor_obj *self) {
     if (!self->open) {
         mp_raise_ValueError(MP_ERROR_TEXT("I/O operation on closed file"));
     }
 }
 
-STATIC int advance(file_descriptor_obj *self, uint32_t n, bool write) {
+static int advance(file_descriptor_obj *self, uint32_t n, bool write) {
     DEBUG(("FILE DEBUG: Advancing from chunk %d, offset %d.\r\n", self->seek_chunk, self->seek_offset));
     self->seek_offset += n;
     if (self->seek_offset == DATA_PER_CHUNK) {
@@ -410,7 +410,7 @@ STATIC int advance(file_descriptor_obj *self, uint32_t n, bool write) {
     return 0;
 }
 
-STATIC mp_uint_t microbit_file_read(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode) {
+static mp_uint_t microbit_file_read(mp_obj_t obj, void *buf, mp_uint_t size, int *errcode) {
     file_descriptor_obj *self = (file_descriptor_obj *)obj;
     check_file_open(self);
     if (self->writable || file_system_chunks[self->start_chunk].marker == FREED_CHUNK) {
@@ -440,7 +440,7 @@ STATIC mp_uint_t microbit_file_read(mp_obj_t obj, void *buf, mp_uint_t size, int
     return bytes_read;
 }
 
-STATIC mp_uint_t microbit_file_write(mp_obj_t obj, const void *buf, mp_uint_t size, int *errcode) {
+static mp_uint_t microbit_file_write(mp_obj_t obj, const void *buf, mp_uint_t size, int *errcode) {
     file_descriptor_obj *self = (file_descriptor_obj *)obj;
     check_file_open(self);
     if (!self->writable || file_system_chunks[self->start_chunk].marker == FREED_CHUNK) {
@@ -463,14 +463,14 @@ STATIC mp_uint_t microbit_file_write(mp_obj_t obj, const void *buf, mp_uint_t si
     return size;
 }
 
-STATIC void microbit_file_close(file_descriptor_obj *fd) {
+static void microbit_file_close(file_descriptor_obj *fd) {
     if (fd->writable) {
         flash_write_byte((uint32_t)&(file_system_chunks[fd->start_chunk].header.end_offset), fd->seek_offset);
     }
     fd->open = false;
 }
 
-STATIC mp_obj_t microbit_file_list(void) {
+static mp_obj_t microbit_file_list(void) {
     mp_obj_t res = mp_obj_new_list(0, NULL);
     for (uint8_t index = 1; index <= chunks_in_file_system; index++) {
         if (file_system_chunks[index].marker == FILE_START) {
@@ -481,7 +481,7 @@ STATIC mp_obj_t microbit_file_list(void) {
     return res;
 }
 
-STATIC mp_obj_t microbit_file_size(mp_obj_t filename) {
+static mp_obj_t microbit_file_size(mp_obj_t filename) {
     size_t name_len;
     const char *name = mp_obj_str_get_data(filename, &name_len);
     uint8_t chunk = microbit_find_file(name, name_len);
@@ -500,7 +500,7 @@ STATIC mp_obj_t microbit_file_size(mp_obj_t filename) {
     return mp_obj_new_int(len);
 }
 
-STATIC mp_uint_t file_read_byte(file_descriptor_obj *fd) {
+static mp_uint_t file_read_byte(file_descriptor_obj *fd) {
     if (file_system_chunks[fd->seek_chunk].next_chunk == UNUSED_CHUNK) {
         uint8_t end_offset = file_system_chunks[fd->start_chunk].header.end_offset;
         if (end_offset == UNUSED_CHUNK || fd->seek_offset == end_offset) {
@@ -535,29 +535,29 @@ mp_import_stat_t os_mbfs_import_stat(const char *path) {
     }
 }
 
-STATIC mp_obj_t os_mbfs_file_name(mp_obj_t self) {
+static mp_obj_t os_mbfs_file_name(mp_obj_t self) {
     file_descriptor_obj *fd = (file_descriptor_obj*)self;
     return microbit_file_name(fd);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_mbfs_file_name_obj, os_mbfs_file_name);
+static MP_DEFINE_CONST_FUN_OBJ_1(os_mbfs_file_name_obj, os_mbfs_file_name);
 
-STATIC mp_obj_t os_mbfs_file_close(mp_obj_t self) {
+static mp_obj_t os_mbfs_file_close(mp_obj_t self) {
     file_descriptor_obj *fd = (file_descriptor_obj*)self;
     microbit_file_close(fd);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_mbfs_file_close_obj, os_mbfs_file_close);
+static MP_DEFINE_CONST_FUN_OBJ_1(os_mbfs_file_close_obj, os_mbfs_file_close);
 
-STATIC mp_obj_t os_mbfs_remove(mp_obj_t name) {
+static mp_obj_t os_mbfs_remove(mp_obj_t name) {
     return microbit_remove(name);
 }
 MP_DEFINE_CONST_FUN_OBJ_1(os_mbfs_remove_obj, os_mbfs_remove);
 
-STATIC mp_obj_t os_mbfs_file___exit__(size_t n_args, const mp_obj_t *args) {
+static mp_obj_t os_mbfs_file___exit__(size_t n_args, const mp_obj_t *args) {
     (void)n_args;
     return os_mbfs_file_close(args[0]);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(os_mbfs_file___exit___obj, 4, 4, os_mbfs_file___exit__);
+static MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(os_mbfs_file___exit___obj, 4, 4, os_mbfs_file___exit__);
 
 typedef struct {
     mp_obj_base_t base;
@@ -565,7 +565,7 @@ typedef struct {
     uint8_t index;
 } os_mbfs_ilistdir_it_t;
 
-STATIC mp_obj_t os_mbfs_ilistdir_it_iternext(mp_obj_t self_in) {
+static mp_obj_t os_mbfs_ilistdir_it_iternext(mp_obj_t self_in) {
     os_mbfs_ilistdir_it_t *self = MP_OBJ_TO_PTR(self_in);
 
     // Read until the next FILE_START chunk.
@@ -590,7 +590,7 @@ STATIC mp_obj_t os_mbfs_ilistdir_it_iternext(mp_obj_t self_in) {
     return MP_OBJ_STOP_ITERATION;
 }
 
-STATIC mp_obj_t os_mbfs_ilistdir(void) {
+static mp_obj_t os_mbfs_ilistdir(void) {
     os_mbfs_ilistdir_it_t *iter = mp_obj_malloc(os_mbfs_ilistdir_it_t, &mp_type_polymorph_iter);
     iter->iternext = os_mbfs_ilistdir_it_iternext;
     iter->index = 1;
@@ -601,12 +601,12 @@ MP_DEFINE_CONST_FUN_OBJ_0(os_mbfs_ilistdir_obj, os_mbfs_ilistdir);
 
 MP_DEFINE_CONST_FUN_OBJ_0(os_mbfs_listdir_obj, microbit_file_list);
 
-STATIC mp_obj_t microbit_file_writable(mp_obj_t self) {
+static mp_obj_t microbit_file_writable(mp_obj_t self) {
     return mp_obj_new_bool(((file_descriptor_obj *)self)->writable);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_file_writable_obj, microbit_file_writable);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_file_writable_obj, microbit_file_writable);
 
-STATIC const mp_map_elem_t os_mbfs_file_locals_dict_table[] = {
+static const mp_map_elem_t os_mbfs_file_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_close), (mp_obj_t)&os_mbfs_file_close_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_name), (mp_obj_t)&os_mbfs_file_name_obj },
     { MP_ROM_QSTR(MP_QSTR___enter__), (mp_obj_t)&mp_identity_obj },
@@ -618,10 +618,10 @@ STATIC const mp_map_elem_t os_mbfs_file_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_readline), (mp_obj_t)&mp_stream_unbuffered_readline_obj},
     { MP_OBJ_NEW_QSTR(MP_QSTR_write), (mp_obj_t)&mp_stream_write_obj},
 };
-STATIC MP_DEFINE_CONST_DICT(os_mbfs_file_locals_dict, os_mbfs_file_locals_dict_table);
+static MP_DEFINE_CONST_DICT(os_mbfs_file_locals_dict, os_mbfs_file_locals_dict_table);
 
 
-STATIC const mp_stream_p_t textio_stream_p = {
+static const mp_stream_p_t textio_stream_p = {
     .read = microbit_file_read,
     .write = microbit_file_write,
     .is_text = true,
@@ -636,7 +636,7 @@ MP_DEFINE_CONST_OBJ_TYPE(
     );
 
 
-STATIC const mp_stream_p_t fileio_stream_p = {
+static const mp_stream_p_t fileio_stream_p = {
     .read = microbit_file_read,
     .write = microbit_file_write,
 };
@@ -684,7 +684,7 @@ mode_error:
     mp_raise_ValueError(MP_ERROR_TEXT("illegal mode"));
 }
 
-STATIC mp_obj_t os_mbfs_stat(mp_obj_t filename) {
+static mp_obj_t os_mbfs_stat(mp_obj_t filename) {
     mp_obj_t file_size = microbit_file_size(filename);
 
     mp_obj_tuple_t *t = MP_OBJ_TO_PTR(mp_obj_new_tuple(10, NULL));

--- a/src/codal_port/modantigravity.c
+++ b/src/codal_port/modantigravity.c
@@ -31,12 +31,12 @@
 #define GET_PIXEL(x, y) microbit_hal_display_get_pixel(x, y)
 #define SET_PIXEL(x, y, v) microbit_hal_display_set_pixel(x, y, v)
 
-STATIC void antigravity_output_char(char c) {
+static void antigravity_output_char(char c) {
     MP_PLAT_PRINT_STRN((char *)&c, 1);
 }
 
 // NOTE: string has to be plain ASCII
-STATIC void antigravity_print_rle(const char *s) {
+static void antigravity_print_rle(const char *s) {
     /* RLE encoding format (2 characters, [0] (first) and [1] (second)):
      * [0] the amount of times to output the specified character (max 127),
      *     bitwise or'ed with 0x80 (to set the last bit, ie: bit 7)
@@ -67,7 +67,7 @@ STATIC void antigravity_print_rle(const char *s) {
  */
 //#define ANTIGRAVITY_COMIC_LARGE
 
-STATIC void antigravity(uint8_t interval_ms) {
+static void antigravity(uint8_t interval_ms) {
     /* move all of the LEDs upwards (we can move them in other directions in the
      * future).
      * first, output the traditional XKCD comic (either in full or micro:size :)
@@ -194,17 +194,17 @@ STATIC void antigravity(uint8_t interval_ms) {
     }
 }
 
-STATIC mp_obj_t antigravity__init__(void) {
+static mp_obj_t antigravity__init__(void) {
     antigravity(200);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(antigravity___init___obj, antigravity__init__);
+static MP_DEFINE_CONST_FUN_OBJ_0(antigravity___init___obj, antigravity__init__);
 
-STATIC const mp_rom_map_elem_t antigravity_module_globals_table[] = {
+static const mp_rom_map_elem_t antigravity_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_antigravity) },
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&antigravity___init___obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(antigravity_module_globals, antigravity_module_globals_table);
+static MP_DEFINE_CONST_DICT(antigravity_module_globals, antigravity_module_globals_table);
 
 const mp_obj_module_t antigravity_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modaudio.c
+++ b/src/codal_port/modaudio.c
@@ -57,7 +57,7 @@ void microbit_audio_stop(void) {
     microbit_hal_audio_stop_expression();
 }
 
-STATIC void audio_buffer_ready(void) {
+static void audio_buffer_ready(void) {
     uint32_t atomic_state = MICROPY_BEGIN_ATOMIC_SECTION();
     audio_output_state_t old_state = audio_output_state;
     audio_output_state = AUDIO_OUTPUT_STATE_DATA_READY;
@@ -67,7 +67,7 @@ STATIC void audio_buffer_ready(void) {
     }
 }
 
-STATIC void audio_data_fetcher(void) {
+static void audio_data_fetcher(void) {
     audio_fetcher_scheduled = false;
     if (audio_source_iter == NULL) {
         return;
@@ -109,11 +109,11 @@ STATIC void audio_data_fetcher(void) {
     }
 }
 
-STATIC mp_obj_t audio_data_fetcher_wrapper(mp_obj_t arg) {
+static mp_obj_t audio_data_fetcher_wrapper(mp_obj_t arg) {
     audio_data_fetcher();
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(audio_data_fetcher_wrapper_obj, audio_data_fetcher_wrapper);
+static MP_DEFINE_CONST_FUN_OBJ_1(audio_data_fetcher_wrapper_obj, audio_data_fetcher_wrapper);
 
 void microbit_hal_audio_ready_callback(void) {
     if (audio_output_state == AUDIO_OUTPUT_STATE_DATA_READY) {
@@ -205,13 +205,13 @@ void microbit_audio_play_source(mp_obj_t src, mp_obj_t pin_select, bool wait, ui
     }
 }
 
-STATIC mp_obj_t stop(void) {
+static mp_obj_t stop(void) {
     microbit_audio_stop();
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_audio_stop_obj, stop);
 
-STATIC mp_obj_t play(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t play(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Note: the return_pin argument is for compatibility with micro:bit v1 and is ignored on v2.
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_source, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
@@ -238,7 +238,7 @@ mp_obj_t is_playing(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_audio_is_playing_obj, is_playing);
 
-STATIC const mp_rom_map_elem_t audio_globals_table[] = {
+static const mp_rom_map_elem_t audio_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_audio) },
     { MP_ROM_QSTR(MP_QSTR_stop), MP_ROM_PTR(&microbit_audio_stop_obj) },
     { MP_ROM_QSTR(MP_QSTR_play), MP_ROM_PTR(&microbit_audio_play_obj) },
@@ -246,7 +246,7 @@ STATIC const mp_rom_map_elem_t audio_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_AudioFrame), MP_ROM_PTR(&microbit_audio_frame_type) },
     { MP_ROM_QSTR(MP_QSTR_SoundEffect), MP_ROM_PTR(&microbit_soundeffect_type) },
 };
-STATIC MP_DEFINE_CONST_DICT(audio_module_globals, audio_globals_table);
+static MP_DEFINE_CONST_DICT(audio_module_globals, audio_globals_table);
 
 const mp_obj_module_t audio_module = {
     .base = { &mp_type_module },
@@ -258,14 +258,14 @@ MP_REGISTER_MODULE(MP_QSTR_audio, audio_module);
 /******************************************************************************/
 // AudioFrame class
 
-STATIC mp_obj_t microbit_audio_frame_new(const mp_obj_type_t *type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
+static mp_obj_t microbit_audio_frame_new(const mp_obj_type_t *type_in, mp_uint_t n_args, mp_uint_t n_kw, const mp_obj_t *args) {
     (void)type_in;
     (void)args;
     mp_arg_check_num(n_args, n_kw, 0, 0, false);
     return microbit_audio_frame_make_new();
 }
 
-STATIC mp_obj_t audio_frame_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value_in) {
+static mp_obj_t audio_frame_subscr(mp_obj_t self_in, mp_obj_t index_in, mp_obj_t value_in) {
     microbit_audio_frame_obj_t *self = (microbit_audio_frame_obj_t *)self_in;
     mp_int_t index = mp_obj_get_int(index_in);
     if (index < 0 || index >= AUDIO_CHUNK_SIZE) {
@@ -376,7 +376,7 @@ static void mult(microbit_audio_frame_obj_t *self, float f) {
     }
 }
 
-STATIC mp_obj_t audio_frame_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
+static mp_obj_t audio_frame_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj_t rhs_in) {
     if (mp_obj_get_type(lhs_in) != &microbit_audio_frame_type) {
         return MP_OBJ_NULL; // op not supported
     }
@@ -402,10 +402,10 @@ STATIC mp_obj_t audio_frame_binary_op(mp_binary_op_t op, mp_obj_t lhs_in, mp_obj
     }
 }
 
-STATIC const mp_map_elem_t microbit_audio_frame_locals_dict_table[] = {
+static const mp_map_elem_t microbit_audio_frame_locals_dict_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_copyfrom), (mp_obj_t)&copyfrom_obj },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_audio_frame_locals_dict, microbit_audio_frame_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_audio_frame_locals_dict, microbit_audio_frame_locals_dict_table);
 
 MP_DEFINE_CONST_OBJ_TYPE(
     microbit_audio_frame_type,

--- a/src/codal_port/modlog.c
+++ b/src/codal_port/modlog.c
@@ -31,7 +31,7 @@
 
 #define TIMESTAMP_DEFAULT_FORMAT (MICROBIT_HAL_LOG_TIMESTAMP_SECONDS)
 
-STATIC void log_check_error(int result) {
+static void log_check_error(int result) {
     if (result == MICROBIT_HAL_DEVICE_NO_RESOURCES) {
         mp_raise_OSError(MP_ENOSPC);
     } else if (result != MICROBIT_HAL_DEVICE_OK) {
@@ -39,13 +39,13 @@ STATIC void log_check_error(int result) {
     }
 }
 
-STATIC mp_obj_t log___init__(void) {
+static mp_obj_t log___init__(void) {
     microbit_hal_log_set_timestamp(TIMESTAMP_DEFAULT_FORMAT);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(log___init___obj, log___init__);
 
-STATIC mp_obj_t log_set_labels(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t log_set_labels(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_timestamp };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_timestamp, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_INT(TIMESTAMP_DEFAULT_FORMAT)} },
@@ -73,15 +73,15 @@ STATIC mp_obj_t log_set_labels(size_t n_args, const mp_obj_t *pos_args, mp_map_t
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(log_set_labels_obj, 0, log_set_labels);
+static MP_DEFINE_CONST_FUN_OBJ_KW(log_set_labels_obj, 0, log_set_labels);
 
-STATIC mp_obj_t log_set_mirroring(mp_obj_t serial) {
+static mp_obj_t log_set_mirroring(mp_obj_t serial) {
     microbit_hal_log_set_mirroring(mp_obj_is_true(serial));
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(log_set_mirroring_obj, log_set_mirroring);
+static MP_DEFINE_CONST_FUN_OBJ_1(log_set_mirroring_obj, log_set_mirroring);
 
-STATIC mp_obj_t log_delete(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t log_delete(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_full };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_full, MP_ARG_BOOL, {.u_bool = false} },
@@ -94,9 +94,9 @@ STATIC mp_obj_t log_delete(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(log_delete_obj, 0, log_delete);
+static MP_DEFINE_CONST_FUN_OBJ_KW(log_delete_obj, 0, log_delete);
 
-STATIC mp_obj_t log_add(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t log_add(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Get the dict to add as a row.
     mp_map_t *map;
     if (n_args == 0) {
@@ -132,9 +132,9 @@ STATIC mp_obj_t log_add(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(log_add_obj, 0, log_add);
+static MP_DEFINE_CONST_FUN_OBJ_KW(log_add_obj, 0, log_add);
 
-STATIC const mp_rom_map_elem_t log_module_globals_table[] = {
+static const mp_rom_map_elem_t log_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_log) },
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&log___init___obj) },
 
@@ -149,7 +149,7 @@ STATIC const mp_rom_map_elem_t log_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_HOURS), MP_ROM_INT(MICROBIT_HAL_LOG_TIMESTAMP_HOURS) },
     { MP_ROM_QSTR(MP_QSTR_DAYS), MP_ROM_INT(MICROBIT_HAL_LOG_TIMESTAMP_DAYS) },
 };
-STATIC MP_DEFINE_CONST_DICT(log_module_globals, log_module_globals_table);
+static MP_DEFINE_CONST_DICT(log_module_globals, log_module_globals_table);
 
 const mp_obj_module_t log_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modlove.c
+++ b/src/codal_port/modlove.c
@@ -28,11 +28,11 @@
 #include "py/mphal.h"
 #include "modmicrobit.h"
 
-STATIC const mp_float_t bright_levels[7] = {
+static const mp_float_t bright_levels[7] = {
     0.0, 1.0 / 9, 2.0 / 9, 4.0 / 9, 6.0 / 9, 7.0 / 9, 1.0,
 };
 
-STATIC void love(int interval_ms) {
+static void love(int interval_ms) {
     microbit_image_obj_t *hearts[MP_ARRAY_SIZE(bright_levels)];
     for (uint i = 0; i < MP_ARRAY_SIZE(bright_levels); i++) {
          hearts[i] = microbit_image_dim(HEART_IMAGE, bright_levels[i]);
@@ -57,20 +57,20 @@ STATIC void love(int interval_ms) {
     microbit_display_clear();
 }
 
-STATIC mp_obj_t love_badaboom(void) {
+static mp_obj_t love_badaboom(void) {
     // make
     love(25);
     // ! war
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(love_badaboom_obj, love_badaboom);
+static MP_DEFINE_CONST_FUN_OBJ_0(love_badaboom_obj, love_badaboom);
 
-STATIC const mp_map_elem_t love_module_globals_table[] = {
+static const mp_map_elem_t love_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_love) },
     { MP_OBJ_NEW_QSTR(MP_QSTR___init__), (mp_obj_t)&love_badaboom_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_badaboom), (mp_obj_t)&love_badaboom_obj },
 };
-STATIC MP_DEFINE_CONST_DICT(love_module_globals, love_module_globals_table);
+static MP_DEFINE_CONST_DICT(love_module_globals, love_module_globals_table);
 
 const mp_obj_module_t love_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modmachine.c
+++ b/src/codal_port/modmachine.c
@@ -33,34 +33,34 @@
 #undef MICROPY_PY_MACHINE
 
 // Returns a string of 8 bytes (64 bits), which is the unique ID for the MCU
-STATIC mp_obj_t machine_unique_id(void) {
+static mp_obj_t machine_unique_id(void) {
     uint32_t dev_id[2];
     mp_hal_unique_id(dev_id);
     return mp_obj_new_bytes((const void*)&dev_id, 8);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(microbit_unique_id_obj, machine_unique_id);
+static MP_DEFINE_CONST_FUN_OBJ_0(microbit_unique_id_obj, machine_unique_id);
 
 // Get the MCU frequency
-STATIC mp_obj_t machine_freq(void) {
+static mp_obj_t machine_freq(void) {
     return MP_OBJ_NEW_SMALL_INT(64000000);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(microbit_freq_obj, machine_freq);
+static MP_DEFINE_CONST_FUN_OBJ_0(microbit_freq_obj, machine_freq);
 
 // Disable interrupt requests
-STATIC mp_obj_t machine_disable_irq(void) {
+static mp_obj_t machine_disable_irq(void) {
     return mp_obj_new_int(mp_hal_disable_irq());
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(machine_disable_irq_obj, machine_disable_irq);
+static MP_DEFINE_CONST_FUN_OBJ_0(machine_disable_irq_obj, machine_disable_irq);
 
 // Enable interrupt requests
-STATIC mp_obj_t machine_enable_irq(mp_obj_t state_in) {
+static mp_obj_t machine_enable_irq(mp_obj_t state_in) {
     uint32_t state = mp_obj_get_int(state_in);
     mp_hal_enable_irq(state);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(machine_enable_irq_obj, machine_enable_irq);
+static MP_DEFINE_CONST_FUN_OBJ_1(machine_enable_irq_obj, machine_enable_irq);
 
-STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
+static const mp_rom_map_elem_t machine_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_machine) },
     { MP_ROM_QSTR(MP_QSTR_unique_id), MP_ROM_PTR(&microbit_unique_id_obj) },
     { MP_ROM_QSTR(MP_QSTR_reset), MP_ROM_PTR(&microbit_reset_obj) },
@@ -75,7 +75,7 @@ STATIC const mp_rom_map_elem_t machine_module_globals_table[] = {
 
     { MP_ROM_QSTR(MP_QSTR_time_pulse_us), MP_ROM_PTR(&machine_time_pulse_us_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
+static MP_DEFINE_CONST_DICT(machine_module_globals, machine_module_globals_table);
 
 const mp_obj_module_t machine_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modmicrobit.c
+++ b/src/codal_port/modmicrobit.c
@@ -32,15 +32,15 @@
 #include "modaudio.h"
 #include "modmicrobit.h"
 
-STATIC mp_obj_t microbit_run_every_new(uint32_t period_ms);
+static mp_obj_t microbit_run_every_new(uint32_t period_ms);
 
-STATIC mp_obj_t microbit_reset_(void) {
+static mp_obj_t microbit_reset_(void) {
     microbit_hal_reset();
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_reset_obj, microbit_reset_);
 
-STATIC mp_obj_t microbit_sleep(mp_obj_t ms_in) {
+static mp_obj_t microbit_sleep(mp_obj_t ms_in) {
     mp_int_t ms;
     if (mp_obj_is_integer(ms_in)) {
         ms = mp_obj_get_int(ms_in);
@@ -54,12 +54,12 @@ STATIC mp_obj_t microbit_sleep(mp_obj_t ms_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(microbit_sleep_obj, microbit_sleep);
 
-STATIC mp_obj_t microbit_running_time(void) {
+static mp_obj_t microbit_running_time(void) {
     return MP_OBJ_NEW_SMALL_INT(mp_hal_ticks_ms());
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_running_time_obj, microbit_running_time);
 
-STATIC mp_obj_t microbit_panic(mp_uint_t n_args, const mp_obj_t *args) {
+static mp_obj_t microbit_panic(mp_uint_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
         // TODO the docs don't mention this, so maybe remove it?
         microbit_hal_panic(999);
@@ -70,12 +70,12 @@ STATIC mp_obj_t microbit_panic(mp_uint_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_panic_obj, 0, 1, microbit_panic);
 
-STATIC mp_obj_t microbit_temperature(void) {
+static mp_obj_t microbit_temperature(void) {
     return mp_obj_new_int(microbit_hal_temperature());
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_temperature_obj, microbit_temperature);
 
-STATIC mp_obj_t microbit_set_volume(mp_obj_t volume_in) {
+static mp_obj_t microbit_set_volume(mp_obj_t volume_in) {
     mp_int_t volume = mp_obj_get_int(volume_in);
     if (volume < 0) {
         volume = 0;
@@ -85,18 +85,18 @@ STATIC mp_obj_t microbit_set_volume(mp_obj_t volume_in) {
     microbit_hal_audio_set_volume(volume);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_set_volume_obj, microbit_set_volume);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_set_volume_obj, microbit_set_volume);
 
-STATIC mp_obj_t microbit_ws2812_write(mp_obj_t pin_in, mp_obj_t buf_in) {
+static mp_obj_t microbit_ws2812_write(mp_obj_t pin_in, mp_obj_t buf_in) {
     uint8_t pin = microbit_obj_get_pin(pin_in)->name;
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
     microbit_hal_pin_write_ws2812(pin, bufinfo.buf, bufinfo.len);
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_2(microbit_ws2812_write_obj, microbit_ws2812_write);
+static MP_DEFINE_CONST_FUN_OBJ_2(microbit_ws2812_write_obj, microbit_ws2812_write);
 
-STATIC mp_obj_t microbit_run_every(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_run_every(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_callback, ARG_days, ARG_h, ARG_min, ARG_s, ARG_ms };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_callback, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -126,9 +126,9 @@ STATIC mp_obj_t microbit_run_every(size_t n_args, const mp_obj_t *pos_args, mp_m
         return MP_OBJ_TYPE_GET_SLOT(mp_obj_get_type(run_every), call)(run_every, 1, 0, &args[ARG_callback].u_obj);
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(microbit_run_every_obj, 0, microbit_run_every);
+static MP_DEFINE_CONST_FUN_OBJ_KW(microbit_run_every_obj, 0, microbit_run_every);
 
-STATIC mp_obj_t microbit_scale(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_scale(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_value, ARG_from_, ARG_to };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_value, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -161,9 +161,9 @@ STATIC mp_obj_t microbit_scale(size_t n_args, const mp_obj_t *pos_args, mp_map_t
         return mp_obj_new_int(MICROPY_FLOAT_C_FUN(nearbyint)(to_value));
     }
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(microbit_scale_obj, 0, microbit_scale);
+static MP_DEFINE_CONST_FUN_OBJ_KW(microbit_scale_obj, 0, microbit_scale);
 
-STATIC const mp_rom_map_elem_t microbit_module_globals_table[] = {
+static const mp_rom_map_elem_t microbit_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_microbit) },
 
     { MP_ROM_QSTR(MP_QSTR_Image), (mp_obj_t)&microbit_image_type },
@@ -217,7 +217,7 @@ STATIC const mp_rom_map_elem_t microbit_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_pin_speaker), MP_ROM_PTR(&microbit_pin_speaker_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(microbit_module_globals, microbit_module_globals_table);
+static MP_DEFINE_CONST_DICT(microbit_module_globals, microbit_module_globals_table);
 
 const mp_obj_module_t microbit_module = {
     .base = { &mp_type_module },
@@ -234,7 +234,7 @@ typedef struct _microbit_run_every_obj_t {
     mp_obj_t user_callback;
 } microbit_run_every_obj_t;
 
-STATIC mp_obj_t microbit_run_every_callback(mp_obj_t self_in) {
+static mp_obj_t microbit_run_every_callback(mp_obj_t self_in) {
     microbit_run_every_obj_t *self = MP_OBJ_TO_PTR(self_in);
 
     if (self->user_callback == MP_OBJ_NULL) {
@@ -264,9 +264,9 @@ STATIC mp_obj_t microbit_run_every_callback(mp_obj_t self_in) {
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(microbit_run_every_callback_obj, microbit_run_every_callback);
+static MP_DEFINE_CONST_FUN_OBJ_1(microbit_run_every_callback_obj, microbit_run_every_callback);
 
-STATIC mp_obj_t microbit_run_every_obj_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
+static mp_obj_t microbit_run_every_obj_call(mp_obj_t self_in, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     microbit_run_every_obj_t *self = MP_OBJ_TO_PTR(self_in);
     mp_arg_check_num(n_args, n_kw, 1, 1, false);
     self->timer.py_callback = MP_OBJ_FROM_PTR(&microbit_run_every_callback_obj);
@@ -275,14 +275,14 @@ STATIC mp_obj_t microbit_run_every_obj_call(mp_obj_t self_in, size_t n_args, siz
     return self_in;
 }
 
-STATIC MP_DEFINE_CONST_OBJ_TYPE(
+static MP_DEFINE_CONST_OBJ_TYPE(
     microbit_run_every_obj_type,
     MP_QSTR_run_every,
     MP_TYPE_FLAG_NONE,
     call, microbit_run_every_obj_call
     );
 
-STATIC mp_obj_t microbit_run_every_new(uint32_t period_ms) {
+static mp_obj_t microbit_run_every_new(uint32_t period_ms) {
     microbit_run_every_obj_t *self = m_new_obj(microbit_run_every_obj_t);
     self->timer.pairheap.base.type = &microbit_run_every_obj_type;
     self->timer.flags = MICROBIT_SOFT_TIMER_FLAG_PY_CALLBACK | MICROBIT_SOFT_TIMER_FLAG_GC_ALLOCATED;

--- a/src/codal_port/modmusic.c
+++ b/src/codal_port/modmusic.c
@@ -66,13 +66,13 @@ typedef struct _music_data_t {
     mp_obj_t async_note;
 } music_data_t;
 
-STATIC uint32_t start_note(const char *note_str, size_t note_len);
+static uint32_t start_note(const char *note_str, size_t note_len);
 
-STATIC void music_output_amplitude(uint32_t amplitude) {
+static void music_output_amplitude(uint32_t amplitude) {
     microbit_hal_pin_write_analog_u10(MICROBIT_HAL_PIN_MIXER, amplitude);
 }
 
-STATIC int music_output_period_us(uint32_t period) {
+static int music_output_period_us(uint32_t period) {
     return microbit_hal_pin_set_analog_period_us(MICROBIT_HAL_PIN_MIXER, period);
 }
 
@@ -132,7 +132,7 @@ void microbit_music_tick(void) {
     }
 }
 
-STATIC void wait_async_music_idle(void) {
+static void wait_async_music_idle(void) {
     nlr_buf_t nlr;
     if (nlr_push(&nlr) == 0) {
         // Wait for the async music state to become idle.
@@ -149,7 +149,7 @@ STATIC void wait_async_music_idle(void) {
     }
 }
 
-STATIC uint32_t start_note(const char *note_str, size_t note_len) {
+static uint32_t start_note(const char *note_str, size_t note_len) {
     music_output_amplitude(MUSIC_OUTPUT_AMPLITUDE_ON);
 
     // [NOTE](#|b)(octave)(:length)
@@ -158,9 +158,9 @@ STATIC uint32_t start_note(const char *note_str, size_t note_len) {
     // array of us periods
 
     // these are the periods of note4 (the octave ascending from middle c) from A->B then C->G
-    STATIC uint16_t periods_us[] = {2273, 2025, 3822, 3405, 3034, 2863, 2551};
+    static uint16_t periods_us[] = {2273, 2025, 3822, 3405, 3034, 2863, 2551};
     // A#, -, C#, D#, -, F#, G#
-    STATIC uint16_t periods_sharps_us[] = {2145, 0, 3608, 3214, 0, 2703, 2408};
+    static uint16_t periods_sharps_us[] = {2145, 0, 3608, 3214, 0, 2703, 2408};
 
     // we'll represent the note as an integer (A=0, G=6)
     // TODO: validate the note
@@ -259,7 +259,7 @@ STATIC uint32_t start_note(const char *note_str, size_t note_len) {
     return gap_ms;
 }
 
-STATIC mp_obj_t microbit_music_reset(void) {
+static mp_obj_t microbit_music_reset(void) {
     music_data->bpm = DEFAULT_BPM;
     music_data->ticks = DEFAULT_TICKS;
     music_data->last_octave = DEFAULT_OCTAVE;
@@ -268,7 +268,7 @@ STATIC mp_obj_t microbit_music_reset(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_music_reset_obj, microbit_music_reset);
 
-STATIC mp_obj_t microbit_music_get_tempo(void) {
+static mp_obj_t microbit_music_get_tempo(void) {
     mp_obj_t tempo_tuple[2];
     tempo_tuple[0] = mp_obj_new_int(music_data->bpm);
     tempo_tuple[1] = mp_obj_new_int(music_data->ticks);
@@ -276,7 +276,7 @@ STATIC mp_obj_t microbit_music_get_tempo(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(microbit_music_get_tempo_obj, microbit_music_get_tempo);
 
-STATIC mp_obj_t microbit_music_stop(mp_uint_t n_args, const mp_obj_t *args) {
+static mp_obj_t microbit_music_stop(mp_uint_t n_args, const mp_obj_t *args) {
     mp_const_obj_t pin;
     if (n_args == 0) {
         pin = MUSIC_OUTPUT_DEFAULT_PIN;
@@ -296,7 +296,7 @@ STATIC mp_obj_t microbit_music_stop(mp_uint_t n_args, const mp_obj_t *args) {
 }
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(microbit_music_stop_obj, 0, 1, microbit_music_stop);
 
-STATIC mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_music, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_obj = MP_OBJ_NULL} },
         { MP_QSTR_pin,   MP_ARG_OBJ, {.u_obj = (mp_obj_t)MUSIC_OUTPUT_DEFAULT_PIN} },
@@ -352,7 +352,7 @@ STATIC mp_obj_t microbit_music_play(mp_uint_t n_args, const mp_obj_t *pos_args, 
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_music_play_obj, 0, microbit_music_play);
 
-STATIC mp_obj_t microbit_music_pitch(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_music_pitch(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_frequency, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_duration, MP_ARG_INT, {.u_int = -1} },
@@ -400,7 +400,7 @@ STATIC mp_obj_t microbit_music_pitch(mp_uint_t n_args, const mp_obj_t *pos_args,
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(microbit_music_pitch_obj, 0, microbit_music_pitch);
 
-STATIC mp_obj_t microbit_music_set_tempo(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t microbit_music_set_tempo(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_ticks, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
         { MP_QSTR_bpm, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
@@ -434,7 +434,7 @@ static mp_obj_t music_init(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(music___init___obj, music_init);
 
-STATIC const mp_rom_map_elem_t microbit_music_locals_dict_table[] = {
+static const mp_rom_map_elem_t microbit_music_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_music) },
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&music___init___obj) },
 
@@ -467,7 +467,7 @@ STATIC const mp_rom_map_elem_t microbit_music_locals_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_POWER_UP), MP_ROM_PTR(&microbit_music_tune_power_up_obj) },
     { MP_ROM_QSTR(MP_QSTR_POWER_DOWN), MP_ROM_PTR(&microbit_music_tune_power_down_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(microbit_music_locals_dict, microbit_music_locals_dict_table);
+static MP_DEFINE_CONST_DICT(microbit_music_locals_dict, microbit_music_locals_dict_table);
 
 const mp_obj_module_t music_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modos.c
+++ b/src/codal_port/modos.c
@@ -40,17 +40,17 @@
 const char microbit_release_string[] = MICROBIT_RELEASE;
 const char microbit_version_string[] = MICROBIT_VERSION;
 
-STATIC const qstr os_uname_info_fields[] = {
+static const qstr os_uname_info_fields[] = {
     MP_QSTR_sysname, MP_QSTR_nodename,
     MP_QSTR_release, MP_QSTR_version, MP_QSTR_machine
 };
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_PY_SYS_PLATFORM);
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_PY_SYS_PLATFORM);
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, microbit_release_string);
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, microbit_version_string);
-STATIC const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROBIT_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
+static const MP_DEFINE_STR_OBJ(os_uname_info_sysname_obj, MICROPY_PY_SYS_PLATFORM);
+static const MP_DEFINE_STR_OBJ(os_uname_info_nodename_obj, MICROPY_PY_SYS_PLATFORM);
+static const MP_DEFINE_STR_OBJ(os_uname_info_release_obj, microbit_release_string);
+static const MP_DEFINE_STR_OBJ(os_uname_info_version_obj, microbit_version_string);
+static const MP_DEFINE_STR_OBJ(os_uname_info_machine_obj, MICROBIT_BOARD_NAME " with " MICROPY_HW_MCU_NAME);
 
-STATIC MP_DEFINE_ATTRTUPLE(
+static MP_DEFINE_ATTRTUPLE(
     os_uname_info_obj,
     os_uname_info_fields,
     5,
@@ -61,20 +61,20 @@ STATIC MP_DEFINE_ATTRTUPLE(
     MP_ROM_PTR(&os_uname_info_machine_obj)
 );
 
-STATIC mp_obj_t os_uname(void) {
+static mp_obj_t os_uname(void) {
     return MP_OBJ_FROM_PTR(&os_uname_info_obj);
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
+static MP_DEFINE_CONST_FUN_OBJ_0(os_uname_obj, os_uname);
 
 #if MICROPY_MBFS
-STATIC mp_obj_t os_size(mp_obj_t filename) {
+static mp_obj_t os_size(mp_obj_t filename) {
     mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(os_mbfs_stat_obj.fun._1(filename));
     return tuple->items[6];
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_1(os_size_obj, os_size);
+static MP_DEFINE_CONST_FUN_OBJ_1(os_size_obj, os_size);
 #endif
 
-STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
+static const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_os) },
 
     { MP_ROM_QSTR(MP_QSTR_uname), MP_ROM_PTR(&os_uname_obj) },
@@ -89,7 +89,7 @@ STATIC const mp_rom_map_elem_t os_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_size), MP_ROM_PTR(&os_size_obj) },
     #endif
 };
-STATIC MP_DEFINE_CONST_DICT(os_module_globals, os_module_globals_table);
+static MP_DEFINE_CONST_DICT(os_module_globals, os_module_globals_table);
 
 const mp_obj_module_t os_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modpower.c
+++ b/src/codal_port/modpower.c
@@ -28,7 +28,7 @@
 #include "py/mphal.h"
 #include "drv_softtimer.h"
 
-STATIC size_t get_array(mp_obj_t *src, mp_obj_t **items) {
+static size_t get_array(mp_obj_t *src, mp_obj_t **items) {
     if (*src == mp_const_none) {
         // None, so an array of length 0.
         *items = NULL;
@@ -45,13 +45,13 @@ STATIC size_t get_array(mp_obj_t *src, mp_obj_t **items) {
     }
 }
 
-STATIC mp_obj_t power_off(void) {
+static mp_obj_t power_off(void) {
     microbit_hal_power_off();
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_0(power_off_obj, power_off);
+static MP_DEFINE_CONST_FUN_OBJ_0(power_off_obj, power_off);
 
-STATIC mp_obj_t power_deep_sleep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t power_deep_sleep(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     enum { ARG_ms, ARG_wake_on, ARG_run_every };
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_ms, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} },
@@ -136,15 +136,15 @@ STATIC mp_obj_t power_deep_sleep(size_t n_args, const mp_obj_t *pos_args, mp_map
 
     return mp_const_none;
 }
-STATIC MP_DEFINE_CONST_FUN_OBJ_KW(power_deep_sleep_obj, 0, power_deep_sleep);
+static MP_DEFINE_CONST_FUN_OBJ_KW(power_deep_sleep_obj, 0, power_deep_sleep);
 
-STATIC const mp_rom_map_elem_t power_module_globals_table[] = {
+static const mp_rom_map_elem_t power_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_power) },
 
     { MP_ROM_QSTR(MP_QSTR_off), MP_ROM_PTR(&power_off_obj) },
     { MP_ROM_QSTR(MP_QSTR_deep_sleep), MP_ROM_PTR(&power_deep_sleep_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(power_module_globals, power_module_globals_table);
+static MP_DEFINE_CONST_DICT(power_module_globals, power_module_globals_table);
 
 const mp_obj_module_t power_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modradio.c
+++ b/src/codal_port/modradio.c
@@ -32,24 +32,24 @@
 #include "py/smallint.h"
 #include "drv_radio.h"
 
-STATIC microbit_radio_config_t radio_config;
+static microbit_radio_config_t radio_config;
 
-STATIC mp_obj_t mod_radio_reset(void);
+static mp_obj_t mod_radio_reset(void);
 
-STATIC void ensure_enabled(void) {
+static void ensure_enabled(void) {
     if (MP_STATE_PORT(radio_buf) == NULL) {
         mp_raise_ValueError(MP_ERROR_TEXT("radio is not enabled"));
     }
 }
 
-STATIC mp_obj_t mod_radio___init__(void) {
+static mp_obj_t mod_radio___init__(void) {
     mod_radio_reset();
     microbit_radio_enable(&radio_config);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio___init___obj, mod_radio___init__);
 
-STATIC mp_obj_t mod_radio_reset(void) {
+static mp_obj_t mod_radio_reset(void) {
     radio_config.max_payload = MICROBIT_RADIO_DEFAULT_MAX_PAYLOAD;
     radio_config.queue_len = MICROBIT_RADIO_DEFAULT_QUEUE_LEN;
     radio_config.channel = MICROBIT_RADIO_DEFAULT_CHANNEL;
@@ -61,7 +61,7 @@ STATIC mp_obj_t mod_radio_reset(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio_reset_obj, mod_radio_reset);
 
-STATIC mp_obj_t mod_radio_config(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t mod_radio_config(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     (void)pos_args; // unused
 
     if (n_args != 0) {
@@ -160,19 +160,19 @@ value_error:
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(mod_radio_config_obj, 0, mod_radio_config);
 
-STATIC mp_obj_t mod_radio_on(void) {
+static mp_obj_t mod_radio_on(void) {
     microbit_radio_enable(&radio_config);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio_on_obj, mod_radio_on);
 
-STATIC mp_obj_t mod_radio_off(void) {
+static mp_obj_t mod_radio_off(void) {
     microbit_radio_disable();
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio_off_obj, mod_radio_off);
 
-STATIC mp_obj_t mod_radio_send_bytes(mp_obj_t buf_in) {
+static mp_obj_t mod_radio_send_bytes(mp_obj_t buf_in) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_READ);
     ensure_enabled();
@@ -181,7 +181,7 @@ STATIC mp_obj_t mod_radio_send_bytes(mp_obj_t buf_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mod_radio_send_bytes_obj, mod_radio_send_bytes);
 
-STATIC mp_obj_t mod_radio_receive_bytes(void) {
+static mp_obj_t mod_radio_receive_bytes(void) {
     ensure_enabled();
     const uint8_t *buf = microbit_radio_peek();
     if (buf == NULL) {
@@ -194,7 +194,7 @@ STATIC mp_obj_t mod_radio_receive_bytes(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio_receive_bytes_obj, mod_radio_receive_bytes);
 
-STATIC mp_obj_t mod_radio_send(mp_obj_t buf_in) {
+static mp_obj_t mod_radio_send(mp_obj_t buf_in) {
     mp_uint_t len;
     const char *data = mp_obj_str_get_data(buf_in, &len);
     ensure_enabled();
@@ -203,7 +203,7 @@ STATIC mp_obj_t mod_radio_send(mp_obj_t buf_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mod_radio_send_obj, mod_radio_send);
 
-STATIC mp_obj_t mod_radio_receive(void) {
+static mp_obj_t mod_radio_receive(void) {
     ensure_enabled();
     const uint8_t *buf = microbit_radio_peek();
     if (buf == NULL) {
@@ -221,7 +221,7 @@ STATIC mp_obj_t mod_radio_receive(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio_receive_obj, mod_radio_receive);
 
-STATIC mp_obj_t mod_radio_receive_bytes_into(mp_obj_t buf_in) {
+static mp_obj_t mod_radio_receive_bytes_into(mp_obj_t buf_in) {
     mp_buffer_info_t bufinfo;
     mp_get_buffer_raise(buf_in, &bufinfo, MP_BUFFER_WRITE);
     ensure_enabled();
@@ -237,7 +237,7 @@ STATIC mp_obj_t mod_radio_receive_bytes_into(mp_obj_t buf_in) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(mod_radio_receive_bytes_into_obj, mod_radio_receive_bytes_into);
 
-STATIC mp_obj_t mod_radio_receive_full(void) {
+static mp_obj_t mod_radio_receive_full(void) {
     ensure_enabled();
     const uint8_t *buf = microbit_radio_peek();
     if (buf == NULL) {
@@ -260,7 +260,7 @@ STATIC mp_obj_t mod_radio_receive_full(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(mod_radio_receive_full_obj, mod_radio_receive_full);
 
-STATIC const mp_map_elem_t radio_module_globals_table[] = {
+static const mp_map_elem_t radio_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_radio) },
     { MP_OBJ_NEW_QSTR(MP_QSTR___init__), (mp_obj_t)&mod_radio___init___obj },
 
@@ -284,7 +284,7 @@ STATIC const mp_map_elem_t radio_module_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR_RATE_2MBIT), MP_OBJ_NEW_SMALL_INT(RADIO_MODE_MODE_Nrf_2Mbit) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(radio_module_globals, radio_module_globals_table);
+static MP_DEFINE_CONST_DICT(radio_module_globals, radio_module_globals_table);
 
 const mp_obj_module_t radio_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modspeech.c
+++ b/src/codal_port/modspeech.c
@@ -104,7 +104,7 @@ void microbit_hal_audio_speech_ready_callback(void) {
     #endif
 }
 
-STATIC void sam_output_reset(microbit_audio_frame_obj_t *src_frame) {
+static void sam_output_reset(microbit_audio_frame_obj_t *src_frame) {
     sam_output_frame = src_frame;
     buf_start_pos = 0;
     last_pos = 0;
@@ -123,7 +123,7 @@ STATIC void sam_output_reset(microbit_audio_frame_obj_t *src_frame) {
     #endif
 }
 
-STATIC void speech_wait_output_drained(void) {
+static void speech_wait_output_drained(void) {
     #if USE_DEDICATED_AUDIO_CHANNEL
     while (speech_output_read >= 0) {
         mp_handle_pending(true);
@@ -147,7 +147,7 @@ STATIC void speech_wait_output_drained(void) {
 }
 
 #if USE_DEDICATED_AUDIO_CHANNEL
-STATIC void speech_output_sample(uint8_t b) {
+static void speech_output_sample(uint8_t b) {
     speech_output_buffer[OUT_CHUNK_SIZE * speech_output_write + speech_output_buffer_idx++] = b;
     if (speech_output_buffer_idx >= OUT_CHUNK_SIZE) {
         speech_wait_output_drained();
@@ -327,7 +327,7 @@ void SamOutputByte(unsigned int pos, unsigned char b) {
 
 // This iterator assumes that the speech renderer can generate samples
 // at least as fast as we can consume them.
-STATIC mp_obj_t next(mp_obj_t iter) {
+static mp_obj_t next(mp_obj_t iter) {
     if (exhausted) {
         return MP_OBJ_STOP_ITERATION;
     }
@@ -344,14 +344,14 @@ STATIC mp_obj_t next(mp_obj_t iter) {
     }
 }
 
-STATIC const mp_obj_type_t speech_iterator_type = {
+static const mp_obj_type_t speech_iterator_type = {
     { &mp_type_type },
     .name = MP_QSTR_iterator,
     .getiter = mp_identity_getiter,
     .iternext = next,
 };
 
-STATIC mp_obj_t make_speech_iter(void) {
+static mp_obj_t make_speech_iter(void) {
     speech_iterator_t *result = m_new_obj(speech_iterator_t);
     result->base.type = &speech_iterator_type;
     result->empty = microbit_audio_frame_make_new();
@@ -361,7 +361,7 @@ STATIC mp_obj_t make_speech_iter(void) {
 
 #endif
 
-STATIC mp_obj_t translate(mp_obj_t words) {
+static mp_obj_t translate(mp_obj_t words) {
     mp_uint_t len, outlen;
     const char *txt = mp_obj_str_get_data(words, &len);
     // Reciter truncates *output* at about 120 characters.
@@ -391,7 +391,7 @@ STATIC mp_obj_t translate(mp_obj_t words) {
 }
 MP_DEFINE_CONST_FUN_OBJ_1(translate_obj, translate);
 
-STATIC mp_obj_t articulate(mp_obj_t phonemes, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args, bool sing) {
+static mp_obj_t articulate(mp_obj_t phonemes, mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args, bool sing) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_pitch,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_PITCH} },
         { MP_QSTR_speed,    MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = DEFAULT_SPEED} },
@@ -470,30 +470,30 @@ STATIC mp_obj_t articulate(mp_obj_t phonemes, mp_uint_t n_args, const mp_obj_t *
     return mp_const_none;
 }
 
-STATIC mp_obj_t say(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t say(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     mp_obj_t phonemes = translate(pos_args[0]);
     return articulate(phonemes, n_args-1, pos_args+1, kw_args, false);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(say_obj, 1, say);
 
-STATIC mp_obj_t pronounce(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t pronounce(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     return articulate(pos_args[0], n_args-1, pos_args+1, kw_args, false);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(pronounce_obj, 1, pronounce);
 
-STATIC mp_obj_t sing(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t sing(mp_uint_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     return articulate(pos_args[0], n_args-1, pos_args+1, kw_args, true);
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(sing_obj, 1, sing);
 
-STATIC const mp_map_elem_t _globals_table[] = {
+static const mp_map_elem_t _globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_speech) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_say), (mp_obj_t)&say_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_sing), (mp_obj_t)&sing_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_pronounce), (mp_obj_t)&pronounce_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_translate), (mp_obj_t)&translate_obj },
 };
-STATIC MP_DEFINE_CONST_DICT(_globals, _globals_table);
+static MP_DEFINE_CONST_DICT(_globals, _globals_table);
 
 const mp_obj_module_t speech_module = {
     .base = { &mp_type_module },

--- a/src/codal_port/modthis.c
+++ b/src/codal_port/modthis.c
@@ -26,7 +26,7 @@
 
 #include "py/runtime.h"
 
-STATIC const char *this_text =
+static const char *this_text =
 "The Zen of MicroPython, by Nicholas H. Tollervey\n"
 "\n"
 "Code,\n"
@@ -41,31 +41,31 @@ STATIC const char *this_text =
 "Happy hacking! :-)\n";
 
 // If you contribute code to this project, add your name here.
-STATIC const char *authors_text =
+static const char *authors_text =
 "MicroPython on the micro:bit is brought to you by:\n"
 "Damien P. George, Mark Shannon, Radomir Dopieralski, Matthew Else,\n"
 "Carol Willing, Tom Viner, Alan Jackson, Nick Coghlan, Joseph Haig,\n"
 "Alex Chan, Andrea Grandi, Paul Egan, Piotr Kasprzyk, Andrew Mulholland,\n"
 "Matt Wheeler, Joe Glancy, Abbie Brooks and Nicholas H. Tollervey.\n";
 
-STATIC mp_obj_t this__init__(void) {
+static mp_obj_t this__init__(void) {
     mp_printf(&mp_plat_print, "%s", this_text);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(this___init___obj, this__init__);
 
-STATIC mp_obj_t this_authors(void) {
+static mp_obj_t this_authors(void) {
     mp_printf(&mp_plat_print, "%s", authors_text);
     return mp_const_none;
 }
 MP_DEFINE_CONST_FUN_OBJ_0(this_authors_obj, this_authors);
 
-STATIC const mp_rom_map_elem_t this_module_globals_table[] = {
+static const mp_rom_map_elem_t this_module_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_this) },
     { MP_ROM_QSTR(MP_QSTR___init__), MP_ROM_PTR(&this___init___obj) },
     { MP_ROM_QSTR(MP_QSTR_authors), MP_ROM_PTR(&this_authors_obj) },
 };
-STATIC MP_DEFINE_CONST_DICT(this_module_globals, this_module_globals_table);
+static MP_DEFINE_CONST_DICT(this_module_globals, this_module_globals_table);
 
 const mp_obj_module_t this_module = {
     .base = { &mp_type_module },


### PR DESCRIPTION
This updates MicroPython to the latest v1.23.0.

This is necessary to fix an issue in MicroPython when compiling with arm-none-eabi-gcc 14.1.  With this PR the firmware now works with this recent gcc version.

There shouldn't be any user facing changes here.

Overall firmware size is reduced by about 1k due to optimisations in MicroPython v1.23.0.