### PR TITLE
codal_app: Update codal-microbit-v2 to v0.2.67.

### DIFF
--- a/src/codal_app/codal.json
+++ b/src/codal_app/codal.json
@@ -2,7 +2,7 @@
     "target": {
         "name": "codal-microbit-v2",
         "url": "https://github.com/lancaster-university/codal-microbit-v2",
-        "branch": "v0.2.66",
+        "branch": "v0.2.67",
         "type": "git",
         "test_ignore": true
     } ,

--- a/src/codal_app/main.cpp
+++ b/src/codal_app/main.cpp
@@ -75,9 +75,6 @@ int main() {
     uBit.audio.setSpeakerEnabled(true);
     uBit.audio.setPinEnabled(false);
 
-    // Initialise the logo pin in capacitive touch mode.
-    uBit.io.logo.isTouched(TouchMode::Capacitative);
-
     mp_main();
     return 0;
 }


### PR DESCRIPTION
Removed workaround needed before CODAL set the uBit.io.logo touch mode to capacitive by default.
Discussion:
- https://github.com/microbit-foundation/micropython-microbit-v2/issues/168

CODAL changelog:
https://github.com/lancaster-university/codal-microbit-v2/blob/master/Changelog.md#v0267